### PR TITLE
feat(analytics): add statistics and reporting modules

### DIFF
--- a/src/climatevision/analytics/__init__.py
+++ b/src/climatevision/analytics/__init__.py
@@ -7,12 +7,61 @@ for translating model predictions into environmental impact metrics.
 
 from climatevision.analytics.carbon import (
     CarbonEstimator,
+    CarbonEstimate,
     estimate_carbon,
     estimate_carbon_loss,
 )
 
+from climatevision.analytics.validation import (
+    GroundTruthValidator,
+    ValidationMetrics,
+    ValidationReport,
+    validate_predictions,
+    compare_model_versions,
+)
+
+from climatevision.analytics.statistics import (
+    t_test_two_sample,
+    mann_whitney_u,
+    linear_trend_analysis,
+    ab_test_models,
+    bootstrap_confidence_interval,
+    HypothesisTestResult,
+    TrendAnalysisResult,
+    ABTestResult,
+)
+
+from climatevision.analytics.reporting import (
+    ReportGenerator,
+    ImpactReport,
+    RegionalMetrics,
+    generate_report,
+)
+
 __all__ = [
+    # Carbon estimation
     "CarbonEstimator",
+    "CarbonEstimate",
     "estimate_carbon",
     "estimate_carbon_loss",
+    # Validation
+    "GroundTruthValidator",
+    "ValidationMetrics",
+    "ValidationReport",
+    "validate_predictions",
+    "compare_model_versions",
+    # Statistics
+    "t_test_two_sample",
+    "mann_whitney_u",
+    "linear_trend_analysis",
+    "ab_test_models",
+    "bootstrap_confidence_interval",
+    "HypothesisTestResult",
+    "TrendAnalysisResult",
+    "ABTestResult",
+    # Reporting
+    "ReportGenerator",
+    "ImpactReport",
+    "RegionalMetrics",
+    "generate_report",
 ]

--- a/src/climatevision/analytics/reporting.py
+++ b/src/climatevision/analytics/reporting.py
@@ -1,0 +1,321 @@
+"""
+Impact Reporting Module
+
+Generates environmental impact reports from model predictions,
+including carbon loss estimates, trend analysis, and KPI dashboards.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RegionalMetrics:
+    """Environmental metrics for a specific region."""
+    region: str
+    period: str
+    total_hectares_analyzed: float
+    deforested_hectares: float
+    deforestation_rate_pct: float
+    carbon_tonnes_lost: float
+    co2_equivalent: float
+    confidence_interval: tuple[float, float]
+    trend_direction: str
+    yoy_change_pct: Optional[float] = None
+
+
+@dataclass
+class ImpactReport:
+    """Complete environmental impact report."""
+    report_id: str
+    generated_at: datetime
+    region: str
+    period: str
+    metrics: RegionalMetrics
+    validation_summary: dict[str, Any]
+    recommendations: list[str]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert report to dictionary for serialization."""
+        data = asdict(self)
+        data["generated_at"] = self.generated_at.isoformat()
+        return data
+
+    def to_json(self) -> str:
+        """Serialize report to JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+
+
+class ReportGenerator:
+    """
+    Generates impact reports from analysis results.
+
+    Combines carbon estimation, validation metrics, and trend analysis
+    into stakeholder-ready reports.
+    """
+
+    def __init__(self, output_dir: Optional[str] = None):
+        self.output_dir = Path(output_dir) if output_dir else Path("outputs/reports")
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def generate_regional_report(
+        self,
+        region: str,
+        period: str,
+        carbon_result: dict[str, Any],
+        validation_metrics: Optional[dict[str, Any]] = None,
+        historical_data: Optional[list[dict]] = None
+    ) -> ImpactReport:
+        """
+        Generate an impact report for a specific region and period.
+
+        Args:
+            region: Geographic region name
+            period: Time period (e.g., "2023-Q2")
+            carbon_result: Results from carbon estimation
+            validation_metrics: Optional validation results
+            historical_data: Optional historical data for trend analysis
+
+        Returns:
+            ImpactReport with all metrics and recommendations
+        """
+        report_id = f"{region}_{period}_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+
+        # Calculate regional metrics
+        metrics = self._compute_regional_metrics(
+            region, period, carbon_result, historical_data
+        )
+
+        # Summarize validation
+        validation_summary = self._summarize_validation(validation_metrics)
+
+        # Generate recommendations
+        recommendations = self._generate_recommendations(
+            metrics, validation_summary
+        )
+
+        report = ImpactReport(
+            report_id=report_id,
+            generated_at=datetime.utcnow(),
+            region=region,
+            period=period,
+            metrics=metrics,
+            validation_summary=validation_summary,
+            recommendations=recommendations,
+            metadata={
+                "model_version": "1.0.0",
+                "data_sources": ["sentinel-2", "landsat-8"],
+            }
+        )
+
+        logger.info(f"Generated impact report: {report_id}")
+        return report
+
+    def _compute_regional_metrics(
+        self,
+        region: str,
+        period: str,
+        carbon_result: dict[str, Any],
+        historical_data: Optional[list[dict]]
+    ) -> RegionalMetrics:
+        """Compute environmental metrics for the region."""
+        hectares = carbon_result.get("hectares", 0)
+        carbon_tonnes = carbon_result.get("carbon_tonnes", 0)
+        co2_eq = carbon_result.get("co2_equivalent", 0)
+        ci_lower = carbon_result.get("ci_lower", 0)
+        ci_upper = carbon_result.get("ci_upper", 0)
+
+        # Estimate total analyzed area (assume 10x deforested area as context)
+        total_hectares = max(hectares * 10, 1000)
+        deforestation_rate = (hectares / total_hectares) * 100 if total_hectares > 0 else 0
+
+        # Trend analysis if historical data available
+        trend_direction = "stable"
+        yoy_change = None
+
+        if historical_data and len(historical_data) >= 2:
+            values = [h.get("carbon_tonnes", 0) for h in historical_data]
+            if len(values) >= 2 and values[-2] > 0:
+                yoy_change = ((values[-1] - values[-2]) / values[-2]) * 100
+                if yoy_change > 5:
+                    trend_direction = "increasing"
+                elif yoy_change < -5:
+                    trend_direction = "decreasing"
+
+        return RegionalMetrics(
+            region=region,
+            period=period,
+            total_hectares_analyzed=round(total_hectares, 2),
+            deforested_hectares=round(hectares, 2),
+            deforestation_rate_pct=round(deforestation_rate, 2),
+            carbon_tonnes_lost=round(carbon_tonnes, 2),
+            co2_equivalent=round(co2_eq, 2),
+            confidence_interval=(round(ci_lower, 2), round(ci_upper, 2)),
+            trend_direction=trend_direction,
+            yoy_change_pct=round(yoy_change, 2) if yoy_change else None
+        )
+
+    def _summarize_validation(
+        self,
+        validation_metrics: Optional[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Summarize validation results for the report."""
+        if not validation_metrics:
+            return {"status": "not_validated", "message": "No ground truth validation performed"}
+
+        return {
+            "status": "validated",
+            "iou": validation_metrics.get("iou"),
+            "f1": validation_metrics.get("f1"),
+            "precision": validation_metrics.get("precision"),
+            "recall": validation_metrics.get("recall"),
+            "passed_threshold": validation_metrics.get("passed", False),
+        }
+
+    def _generate_recommendations(
+        self,
+        metrics: RegionalMetrics,
+        validation_summary: dict[str, Any]
+    ) -> list[str]:
+        """Generate actionable recommendations based on metrics."""
+        recommendations = []
+
+        # High deforestation rate
+        if metrics.deforestation_rate_pct > 5:
+            recommendations.append(
+                f"CRITICAL: Deforestation rate of {metrics.deforestation_rate_pct:.1f}% "
+                "detected. Recommend immediate field investigation."
+            )
+
+        # Increasing trend
+        if metrics.trend_direction == "increasing":
+            recommendations.append(
+                "Deforestation trend is INCREASING. Consider enhanced monitoring frequency."
+            )
+
+        # High carbon loss
+        if metrics.carbon_tonnes_lost > 10000:
+            recommendations.append(
+                f"Significant carbon loss of {metrics.carbon_tonnes_lost:,.0f} tonnes detected. "
+                "Consider alerting relevant conservation authorities."
+            )
+
+        # Validation issues
+        if validation_summary.get("iou") and validation_summary["iou"] < 0.6:
+            recommendations.append(
+                "Model accuracy below threshold. Results should be verified with ground truth."
+            )
+
+        if not recommendations:
+            recommendations.append(
+                "Metrics within normal ranges. Continue standard monitoring."
+            )
+
+        return recommendations
+
+    def save_report(self, report: ImpactReport, format: str = "json") -> Path:
+        """
+        Save report to file.
+
+        Args:
+            report: The report to save
+            format: Output format ("json" or "html")
+
+        Returns:
+            Path to saved report file
+        """
+        filename = f"{report.report_id}_impact_report.{format}"
+        filepath = self.output_dir / filename
+
+        if format == "json":
+            with open(filepath, "w") as f:
+                f.write(report.to_json())
+        elif format == "html":
+            html_content = self._render_html_report(report)
+            with open(filepath, "w") as f:
+                f.write(html_content)
+
+        logger.info(f"Saved report to {filepath}")
+        return filepath
+
+    def _render_html_report(self, report: ImpactReport) -> str:
+        """Render report as HTML."""
+        metrics = report.metrics
+        return f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>Impact Report - {report.region} {report.period}</title>
+    <style>
+        body {{ font-family: Arial, sans-serif; margin: 40px; }}
+        h1 {{ color: #2e7d32; }}
+        .metric {{ margin: 10px 0; padding: 10px; background: #f5f5f5; }}
+        .critical {{ color: #d32f2f; font-weight: bold; }}
+    </style>
+</head>
+<body>
+    <h1>Environmental Impact Report</h1>
+    <p><strong>Region:</strong> {report.region}</p>
+    <p><strong>Period:</strong> {report.period}</p>
+    <p><strong>Generated:</strong> {report.generated_at.strftime('%Y-%m-%d %H:%M UTC')}</p>
+
+    <h2>Key Metrics</h2>
+    <div class="metric">
+        <strong>Deforested Area:</strong> {metrics.deforested_hectares:,.2f} hectares
+    </div>
+    <div class="metric">
+        <strong>Carbon Loss:</strong> {metrics.carbon_tonnes_lost:,.2f} tonnes CO2e
+    </div>
+    <div class="metric">
+        <strong>Confidence Interval:</strong> {metrics.confidence_interval[0]:,.0f} - {metrics.confidence_interval[1]:,.0f} tonnes
+    </div>
+    <div class="metric">
+        <strong>Trend:</strong> {metrics.trend_direction}
+    </div>
+
+    <h2>Recommendations</h2>
+    <ul>
+        {''.join(f'<li>{r}</li>' for r in report.recommendations)}
+    </ul>
+</body>
+</html>"""
+
+
+def generate_report(
+    region: str,
+    period: str,
+    carbon_result: dict[str, Any],
+    validation_metrics: Optional[dict[str, Any]] = None,
+    output_dir: str = "outputs/reports/"
+) -> Path:
+    """
+    Convenience function to generate and save an impact report.
+
+    Args:
+        region: Geographic region
+        period: Time period
+        carbon_result: Carbon estimation results
+        validation_metrics: Optional validation metrics
+        output_dir: Output directory for reports
+
+    Returns:
+        Path to saved report file
+    """
+    generator = ReportGenerator(output_dir)
+    report = generator.generate_regional_report(
+        region=region,
+        period=period,
+        carbon_result=carbon_result,
+        validation_metrics=validation_metrics
+    )
+    return generator.save_report(report, format="json")

--- a/src/climatevision/analytics/statistics.py
+++ b/src/climatevision/analytics/statistics.py
@@ -1,0 +1,329 @@
+"""
+Statistical Testing and Analysis Module
+
+Provides hypothesis testing, trend analysis, and A/B testing
+capabilities for model comparison and environmental data analysis.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Literal, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HypothesisTestResult:
+    """Result from a statistical hypothesis test."""
+    test_name: str
+    statistic: float
+    p_value: float
+    reject_null: bool
+    confidence_level: float
+    effect_size: Optional[float]
+    interpretation: str
+
+
+@dataclass
+class TrendAnalysisResult:
+    """Result from time series trend analysis."""
+    slope: float
+    intercept: float
+    r_squared: float
+    p_value: float
+    trend_direction: Literal["increasing", "decreasing", "stable"]
+    percent_change: float
+    confidence_interval: tuple[float, float]
+
+
+@dataclass
+class ABTestResult:
+    """Result from A/B model comparison test."""
+    model_a_mean: float
+    model_b_mean: float
+    difference: float
+    p_value: float
+    significant: bool
+    better_model: Literal["A", "B", "no_difference"]
+    confidence_interval: tuple[float, float]
+    sample_size: int
+
+
+def t_test_two_sample(
+    sample_a: np.ndarray,
+    sample_b: np.ndarray,
+    alpha: float = 0.05
+) -> HypothesisTestResult:
+    """
+    Perform two-sample t-test for comparing model predictions.
+
+    Args:
+        sample_a: First sample array
+        sample_b: Second sample array
+        alpha: Significance level
+
+    Returns:
+        HypothesisTestResult with test statistics
+    """
+    n_a, n_b = len(sample_a), len(sample_b)
+    mean_a, mean_b = sample_a.mean(), sample_b.mean()
+    var_a, var_b = sample_a.var(ddof=1), sample_b.var(ddof=1)
+
+    # Pooled standard error
+    se = np.sqrt(var_a / n_a + var_b / n_b)
+    t_stat = (mean_a - mean_b) / se if se > 0 else 0
+
+    # Degrees of freedom (Welch's approximation)
+    if var_a > 0 and var_b > 0:
+        df = ((var_a / n_a + var_b / n_b) ** 2 /
+              ((var_a / n_a) ** 2 / (n_a - 1) + (var_b / n_b) ** 2 / (n_b - 1)))
+    else:
+        df = n_a + n_b - 2
+
+    # Approximate p-value using normal distribution for large samples
+    p_value = 2 * (1 - _norm_cdf(abs(t_stat)))
+
+    # Cohen's d effect size
+    pooled_std = np.sqrt(((n_a - 1) * var_a + (n_b - 1) * var_b) / (n_a + n_b - 2))
+    effect_size = (mean_a - mean_b) / pooled_std if pooled_std > 0 else 0
+
+    reject_null = p_value < alpha
+
+    interpretation = (
+        f"Significant difference detected (p={p_value:.4f})" if reject_null
+        else f"No significant difference (p={p_value:.4f})"
+    )
+
+    return HypothesisTestResult(
+        test_name="Two-Sample T-Test (Welch's)",
+        statistic=round(t_stat, 4),
+        p_value=round(p_value, 4),
+        reject_null=reject_null,
+        confidence_level=1 - alpha,
+        effect_size=round(effect_size, 4),
+        interpretation=interpretation
+    )
+
+
+def mann_whitney_u(
+    sample_a: np.ndarray,
+    sample_b: np.ndarray,
+    alpha: float = 0.05
+) -> HypothesisTestResult:
+    """
+    Non-parametric Mann-Whitney U test for comparing distributions.
+
+    Useful when data may not be normally distributed.
+    """
+    n_a, n_b = len(sample_a), len(sample_b)
+
+    # Combine and rank
+    combined = np.concatenate([sample_a, sample_b])
+    ranks = np.argsort(np.argsort(combined)) + 1
+
+    # Sum of ranks for sample A
+    r_a = ranks[:n_a].sum()
+
+    # U statistic
+    u_a = r_a - n_a * (n_a + 1) / 2
+    u_b = n_a * n_b - u_a
+    u_stat = min(u_a, u_b)
+
+    # Normal approximation for large samples
+    mu = n_a * n_b / 2
+    sigma = np.sqrt(n_a * n_b * (n_a + n_b + 1) / 12)
+    z = (u_stat - mu) / sigma if sigma > 0 else 0
+
+    p_value = 2 * (1 - _norm_cdf(abs(z)))
+    reject_null = p_value < alpha
+
+    # Effect size (rank-biserial correlation)
+    effect_size = 1 - (2 * u_stat) / (n_a * n_b)
+
+    return HypothesisTestResult(
+        test_name="Mann-Whitney U Test",
+        statistic=round(u_stat, 4),
+        p_value=round(p_value, 4),
+        reject_null=reject_null,
+        confidence_level=1 - alpha,
+        effect_size=round(effect_size, 4),
+        interpretation=f"{'Significant' if reject_null else 'No significant'} difference in distributions"
+    )
+
+
+def linear_trend_analysis(
+    values: np.ndarray,
+    time_points: Optional[np.ndarray] = None
+) -> TrendAnalysisResult:
+    """
+    Analyze linear trend in time series data.
+
+    Args:
+        values: Array of values over time
+        time_points: Optional time indices (default: 0 to n-1)
+
+    Returns:
+        TrendAnalysisResult with slope, significance, and direction
+    """
+    n = len(values)
+    if time_points is None:
+        time_points = np.arange(n)
+
+    # Linear regression via least squares
+    x_mean = time_points.mean()
+    y_mean = values.mean()
+
+    ss_xy = ((time_points - x_mean) * (values - y_mean)).sum()
+    ss_xx = ((time_points - x_mean) ** 2).sum()
+
+    slope = ss_xy / ss_xx if ss_xx > 0 else 0
+    intercept = y_mean - slope * x_mean
+
+    # Predictions and residuals
+    predictions = slope * time_points + intercept
+    ss_res = ((values - predictions) ** 2).sum()
+    ss_tot = ((values - y_mean) ** 2).sum()
+
+    r_squared = 1 - ss_res / ss_tot if ss_tot > 0 else 0
+
+    # Standard error and t-statistic
+    if n > 2 and ss_xx > 0:
+        se_slope = np.sqrt(ss_res / (n - 2) / ss_xx)
+        t_stat = slope / se_slope if se_slope > 0 else 0
+        p_value = 2 * (1 - _norm_cdf(abs(t_stat)))
+    else:
+        p_value = 1.0
+
+    # Trend direction
+    if p_value < 0.05:
+        trend_direction = "increasing" if slope > 0 else "decreasing"
+    else:
+        trend_direction = "stable"
+
+    # Percent change over the series
+    start_val = slope * time_points[0] + intercept
+    end_val = slope * time_points[-1] + intercept
+    percent_change = ((end_val - start_val) / abs(start_val) * 100) if start_val != 0 else 0
+
+    # 95% CI for slope
+    if n > 2 and ss_xx > 0:
+        ci_margin = 1.96 * se_slope
+        ci = (slope - ci_margin, slope + ci_margin)
+    else:
+        ci = (slope, slope)
+
+    return TrendAnalysisResult(
+        slope=round(slope, 6),
+        intercept=round(intercept, 4),
+        r_squared=round(r_squared, 4),
+        p_value=round(p_value, 4),
+        trend_direction=trend_direction,
+        percent_change=round(percent_change, 2),
+        confidence_interval=(round(ci[0], 6), round(ci[1], 6))
+    )
+
+
+def ab_test_models(
+    metrics_a: np.ndarray,
+    metrics_b: np.ndarray,
+    metric_name: str = "IoU",
+    alpha: float = 0.05
+) -> ABTestResult:
+    """
+    A/B test comparing two model versions on the same dataset.
+
+    Args:
+        metrics_a: Metrics from model A (e.g., IoU scores per image)
+        metrics_b: Metrics from model B
+        metric_name: Name of metric for reporting
+        alpha: Significance level
+
+    Returns:
+        ABTestResult with comparison statistics
+    """
+    mean_a = float(metrics_a.mean())
+    mean_b = float(metrics_b.mean())
+    diff = mean_a - mean_b
+
+    # Paired t-test for matched samples
+    if len(metrics_a) == len(metrics_b):
+        differences = metrics_a - metrics_b
+        n = len(differences)
+        d_mean = differences.mean()
+        d_std = differences.std(ddof=1)
+
+        se = d_std / np.sqrt(n) if n > 0 else 0
+        t_stat = d_mean / se if se > 0 else 0
+        p_value = 2 * (1 - _norm_cdf(abs(t_stat)))
+
+        ci_margin = 1.96 * se
+        ci = (d_mean - ci_margin, d_mean + ci_margin)
+    else:
+        # Unpaired test
+        result = t_test_two_sample(metrics_a, metrics_b, alpha)
+        p_value = result.p_value
+        se = abs(diff) / abs(result.statistic) if result.statistic != 0 else 0
+        ci = (diff - 1.96 * se, diff + 1.96 * se)
+
+    significant = p_value < alpha
+
+    if not significant:
+        better = "no_difference"
+    else:
+        better = "A" if diff > 0 else "B"
+
+    return ABTestResult(
+        model_a_mean=round(mean_a, 4),
+        model_b_mean=round(mean_b, 4),
+        difference=round(diff, 4),
+        p_value=round(p_value, 4),
+        significant=significant,
+        better_model=better,
+        confidence_interval=(round(ci[0], 4), round(ci[1], 4)),
+        sample_size=len(metrics_a)
+    )
+
+
+def bootstrap_confidence_interval(
+    data: np.ndarray,
+    statistic_func: callable = np.mean,
+    n_bootstrap: int = 1000,
+    confidence: float = 0.95
+) -> tuple[float, float, float]:
+    """
+    Compute bootstrap confidence interval for any statistic.
+
+    Args:
+        data: Input data array
+        statistic_func: Function to compute statistic (default: mean)
+        n_bootstrap: Number of bootstrap samples
+        confidence: Confidence level
+
+    Returns:
+        Tuple of (point_estimate, ci_lower, ci_upper)
+    """
+    rng = np.random.default_rng(42)
+    n = len(data)
+
+    bootstrap_stats = []
+    for _ in range(n_bootstrap):
+        sample = rng.choice(data, size=n, replace=True)
+        bootstrap_stats.append(statistic_func(sample))
+
+    bootstrap_stats = np.array(bootstrap_stats)
+
+    alpha = 1 - confidence
+    ci_lower = float(np.percentile(bootstrap_stats, 100 * alpha / 2))
+    ci_upper = float(np.percentile(bootstrap_stats, 100 * (1 - alpha / 2)))
+    point_estimate = float(statistic_func(data))
+
+    return point_estimate, ci_lower, ci_upper
+
+
+def _norm_cdf(x: float) -> float:
+    """Approximation of standard normal CDF."""
+    return 0.5 * (1 + np.tanh(np.sqrt(2 / np.pi) * (x + 0.044715 * x**3)))


### PR DESCRIPTION
## Summary
- Add comprehensive statistical testing module with hypothesis testing and A/B comparison
- Add impact reporting module for stakeholder-ready environmental reports
- Update module exports for clean public API

## Changes
- `src/climatevision/analytics/statistics.py`: Statistical testing (t-test, Mann-Whitney, trend analysis)
- `src/climatevision/analytics/reporting.py`: Impact report generation (JSON/HTML)
- `src/climatevision/analytics/__init__.py`: Updated module exports

## Test plan
- [ ] Verify t_test_two_sample returns correct p-values
- [ ] Test trend analysis on sample time series data
- [ ] Generate sample impact report and verify JSON output
- [ ] Check HTML report renders correctly in browser
- [ ] Validate all exports work: `from climatevision.analytics import generate_report`

Author: Francis Umo (@franchaise)

Generated with Claude Code