### PR TITLE
feat(data): GEE tile downloader, band mapping, and cloud masking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,8 @@ ENV/
 !notebooks/*.ipynb
 
 # Data
-data/
-datasets/
+/data/
+/datasets/
 *.tif
 *.tiff
 *.h5

--- a/src/climatevision/data/__init__.py
+++ b/src/climatevision/data/__init__.py
@@ -1,7 +1,16 @@
 from .dataset import ForestDataset, create_dataloaders
 from .augmentation import get_train_transforms, get_val_transforms
-from .preprocessing import Sentinel2Normalizer, compute_dataset_stats
+from .preprocessing import Sentinel2Normalizer, compute_dataset_stats, apply_scl_cloud_mask
 from .synthetic import generate_synthetic_dataset
+from .gee_downloader import download_tile_for_analysis
+from .band_mapping import (
+    get_bands_for_analysis,
+    get_bands_for_analysis_with_scl,
+    get_band_indices,
+    is_analysis_enabled,
+    list_enabled_analysis_types,
+    get_model_config,
+)
 from .validation import (
     DataValidationError,
     validate_image_shape,
@@ -26,8 +35,18 @@ __all__ = [
     # Preprocessing
     "Sentinel2Normalizer",
     "compute_dataset_stats",
+    "apply_scl_cloud_mask",
     # Synthetic
     "generate_synthetic_dataset",
+    # GEE
+    "download_tile_for_analysis",
+    # Band mapping
+    "get_bands_for_analysis",
+    "get_bands_for_analysis_with_scl",
+    "get_band_indices",
+    "is_analysis_enabled",
+    "list_enabled_analysis_types",
+    "get_model_config",
     # Validation
     "DataValidationError",
     "validate_image_shape",

--- a/src/climatevision/data/band_mapping.py
+++ b/src/climatevision/data/band_mapping.py
@@ -1,0 +1,109 @@
+"""
+Analysis-specific Sentinel-2 band mapping utilities.
+
+Provides a single source of truth for which spectral bands each
+climate analysis type requires, derived from config.yaml.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_CONFIG_PATH = _PROJECT_ROOT / "config.yaml"
+
+# Full Sentinel-2 L2A 13-band stack in canonical order
+SENTINEL2_BAND_ORDER = [
+    "B01", "B02", "B03", "B04",
+    "B05", "B06", "B07", "B08",
+    "B8A", "B09", "B10", "B11", "B12",
+]
+
+# Scene Classification Layer (SCL) is not part of the 13 reflectance bands
+# but is essential for cloud masking.
+SCL_BAND = "SCL"
+
+
+def _load_config() -> dict[str, Any]:
+    """Load the master config.yaml once and cache it."""
+    with open(_CONFIG_PATH, "r") as f:
+        return yaml.safe_load(f)
+
+
+def get_bands_for_analysis(analysis_type: str) -> list[str]:
+    """
+    Return the Sentinel-2 band names required for *analysis_type*.
+
+    The bands are read from ``config.yaml`` and are guaranteed to be
+    returned in the same order they are declared there.
+    """
+    cfg = _load_config()
+    analysis_cfg = cfg.get("analysis_types", {}).get(analysis_type, {})
+    bands = analysis_cfg.get("bands", ["B04", "B03", "B02", "B08"])
+    return list(bands)
+
+
+def get_bands_for_analysis_with_scl(analysis_type: str) -> list[str]:
+    """
+    Return required bands plus the SCL band for cloud masking.
+
+    If SCL is already in the band list it is not duplicated.
+    """
+    bands = get_bands_for_analysis(analysis_type)
+    if SCL_BAND not in bands:
+        bands = bands + [SCL_BAND]
+    return bands
+
+
+def get_band_indices(band_names: list[str]) -> list[int]:
+    """
+    Map Sentinel-2 band names to zero-based indices in the 13-band stack.
+
+    Raises:
+        ValueError: If a band name is not recognised.
+    """
+    indices = []
+    for b in band_names:
+        if b == SCL_BAND:
+            # SCL does not belong to the 13 reflectance bands;
+            # callers that need an index in a multi-band array should
+            # append it separately and compute len(reflectance_bands).
+            raise ValueError(
+                f"SCL is not part of the 13-band reflectance stack. "
+                f"Append it manually after resolving reflectance indices."
+            )
+        if b not in SENTINEL2_BAND_ORDER:
+            raise ValueError(f"Unknown Sentinel-2 band: {b}")
+        indices.append(SENTINEL2_BAND_ORDER.index(b))
+    return indices
+
+
+def is_analysis_enabled(analysis_type: str) -> bool:
+    """Return True if the analysis type is enabled in config.yaml."""
+    cfg = _load_config()
+    analysis_cfg = cfg.get("analysis_types", {}).get(analysis_type, {})
+    return bool(analysis_cfg.get("enabled", False))
+
+
+def list_enabled_analysis_types() -> list[str]:
+    """Return all analysis type names that are currently enabled."""
+    cfg = _load_config()
+    return [
+        name
+        for name, analysis_cfg in cfg.get("analysis_types", {}).items()
+        if analysis_cfg.get("enabled", False)
+    ]
+
+
+def get_model_config(analysis_type: str) -> dict[str, Any]:
+    """
+    Return the ``model`` subsection for an analysis type.
+
+    This contains keys such as ``architecture``, ``in_channels``,
+    and ``num_classes``.
+    """
+    cfg = _load_config()
+    analysis_cfg = cfg.get("analysis_types", {}).get(analysis_type, {})
+    return dict(analysis_cfg.get("model", {}))

--- a/src/climatevision/data/band_mapping.py
+++ b/src/climatevision/data/band_mapping.py
@@ -6,6 +6,7 @@ climate analysis type requires, derived from config.yaml.
 """
 from __future__ import annotations
 
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,7 @@ SENTINEL2_BAND_ORDER = [
 SCL_BAND = "SCL"
 
 
+@lru_cache(maxsize=1)
 def _load_config() -> dict[str, Any]:
     """Load the master config.yaml once and cache it."""
     with open(_CONFIG_PATH, "r") as f:

--- a/src/climatevision/data/gee_downloader.py
+++ b/src/climatevision/data/gee_downloader.py
@@ -7,7 +7,6 @@ and include a metadata dict that labels synthetic scenes explicitly.
 """
 from __future__ import annotations
 
-import json
 import logging
 import os
 import tempfile
@@ -16,12 +15,12 @@ from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np
-import yaml
+
+from .band_mapping import get_bands_for_analysis
 
 logger = logging.getLogger(__name__)
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
-_CONFIG_PATH = _PROJECT_ROOT / "config.yaml"
 _SATELLITE_DIR = _PROJECT_ROOT / "data" / "satellite"
 
 # Standard Sentinel-2 band name → GEE asset name mapping
@@ -40,20 +39,6 @@ _BAND_NAME_TO_GEE = {
     "B11": "B11",
     "B12": "B12",
 }
-
-
-def _load_config() -> dict[str, Any]:
-    """Load the master config.yaml."""
-    with open(_CONFIG_PATH, "r") as f:
-        return yaml.safe_load(f)
-
-
-def _get_bands_for_analysis(analysis_type: str) -> list[str]:
-    """Return Sentinel-2 band list for a given analysis type from config.yaml."""
-    cfg = _load_config()
-    analysis_cfg = cfg.get("analysis_types", {}).get(analysis_type, {})
-    bands = analysis_cfg.get("bands", ["B04", "B03", "B02", "B08"])
-    return list(bands)
 
 
 def _initialize_ee() -> Any:
@@ -75,6 +60,17 @@ def _initialize_ee() -> Any:
     else:
         ee.Initialize()
     return ee
+
+
+def _get_default_tile_size() -> int:
+    """Read the default tile size from config.yaml."""
+    import yaml
+
+    config_path = _PROJECT_ROOT / "config.yaml"
+    with open(config_path, "r") as f:
+        cfg = yaml.safe_load(f)
+    image_size = cfg.get("data", {}).get("image_size", [256, 256])
+    return int(image_size[0])
 
 
 def download_tile_for_analysis(
@@ -125,7 +121,7 @@ def download_tile_for_analysis(
             out_path=out_path,
         )
 
-    bands = _get_bands_for_analysis(analysis_type)
+    bands = get_bands_for_analysis(analysis_type)
     gee_bands = [_BAND_NAME_TO_GEE[b] for b in bands]
     if include_scl and "SCL" not in gee_bands:
         gee_bands.append("SCL")
@@ -211,9 +207,10 @@ def _generate_synthetic_tile(
     """
     rasterio = __import__("rasterio")
 
-    bands = _get_bands_for_analysis(analysis_type)
+    bands = get_bands_for_analysis(analysis_type)
     n_bands = len(bands)
-    h, w = 256, 256
+    tile_size = _get_default_tile_size()
+    h, w = tile_size, tile_size
 
     # Seed RNG from bbox so the same region is deterministic
     seed = int(abs(sum(v * 1000 * (i + 1) for i, v in enumerate(bbox)))) % (2 ** 31)

--- a/src/climatevision/data/gee_downloader.py
+++ b/src/climatevision/data/gee_downloader.py
@@ -1,0 +1,263 @@
+"""
+Google Earth Engine tile downloader for ClimateVision.
+
+Provides analysis-aware Sentinel-2 tile downloads with a synthetic fallback
+when GEE credentials are unavailable. Downloaded tiles are saved as GeoTIFF
+and include a metadata dict that labels synthetic scenes explicitly.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_CONFIG_PATH = _PROJECT_ROOT / "config.yaml"
+_SATELLITE_DIR = _PROJECT_ROOT / "data" / "satellite"
+
+# Standard Sentinel-2 band name → GEE asset name mapping
+_BAND_NAME_TO_GEE = {
+    "B01": "B1",
+    "B02": "B2",
+    "B03": "B3",
+    "B04": "B4",
+    "B05": "B5",
+    "B06": "B6",
+    "B07": "B7",
+    "B08": "B8",
+    "B8A": "B8A",
+    "B09": "B9",
+    "B10": "B10",
+    "B11": "B11",
+    "B12": "B12",
+}
+
+
+def _load_config() -> dict[str, Any]:
+    """Load the master config.yaml."""
+    with open(_CONFIG_PATH, "r") as f:
+        return yaml.safe_load(f)
+
+
+def _get_bands_for_analysis(analysis_type: str) -> list[str]:
+    """Return Sentinel-2 band list for a given analysis type from config.yaml."""
+    cfg = _load_config()
+    analysis_cfg = cfg.get("analysis_types", {}).get(analysis_type, {})
+    bands = analysis_cfg.get("bands", ["B04", "B03", "B02", "B08"])
+    return list(bands)
+
+
+def _initialize_ee() -> Any:
+    """Lazy import and initialise Google Earth Engine."""
+    import ee  # noqa
+
+    project = os.getenv("GEE_PROJECT_ID")
+    svc_account = os.getenv("GEE_SERVICE_ACCOUNT")
+    key_file = os.getenv("GEE_SERVICE_ACCOUNT_KEY")
+
+    if key_file and not os.path.isabs(key_file):
+        key_file = str(_PROJECT_ROOT / key_file)
+
+    if svc_account and key_file and os.path.exists(key_file):
+        credentials = ee.ServiceAccountCredentials(svc_account, key_file)
+        ee.Initialize(credentials)
+    elif project:
+        ee.Initialize(project=project)
+    else:
+        ee.Initialize()
+    return ee
+
+
+def download_tile_for_analysis(
+    bbox: list[float],
+    start_date: str,
+    end_date: str,
+    analysis_type: str = "deforestation",
+    output_dir: str | Path | None = None,
+    scale_m: int = 100,
+    include_scl: bool = True,
+) -> tuple[Path, dict[str, Any]]:
+    """
+    Download a median Sentinel-2 composite for the given bbox and date range.
+
+    Args:
+        bbox: [west, south, east, north] in WGS84.
+        start_date: Start date (YYYY-MM-DD).
+        end_date: End date (YYYY-MM-DD).
+        analysis_type: One of the keys in config.yaml ``analysis_types``.
+        output_dir: Where to save the GeoTIFF. Defaults to ``data/satellite/``.
+        scale_m: GEE export resolution in metres.
+        include_scl: Whether to append the SCL band for cloud masking.
+
+    Returns:
+        (file_path, metadata_dict).  If GEE is unavailable, the synthetic
+        fallback is used and ``metadata["is_synthetic"]`` is ``True``.
+    """
+    if output_dir is None:
+        output_dir = _SATELLITE_DIR
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    safe_start = start_date.replace("-", "")
+    safe_end = end_date.replace("-", "")
+    stem = f"{analysis_type}_{safe_start}_{safe_end}_{'_'.join(str(round(c, 4)) for c in bbox)}"
+    out_path = output_dir / f"{stem}.tif"
+
+    try:
+        ee = _initialize_ee()
+        rasterio = __import__("rasterio")
+    except Exception as exc:
+        logger.warning("GEE unavailable (%s). Using synthetic fallback.", exc)
+        return _generate_synthetic_tile(
+            bbox=bbox,
+            start_date=start_date,
+            end_date=end_date,
+            analysis_type=analysis_type,
+            out_path=out_path,
+        )
+
+    bands = _get_bands_for_analysis(analysis_type)
+    gee_bands = [_BAND_NAME_TO_GEE[b] for b in bands]
+    if include_scl and "SCL" not in gee_bands:
+        gee_bands.append("SCL")
+
+    region = ee.Geometry.Rectangle(bbox)
+    collection = (
+        ee.ImageCollection("COPERNICUS/S2_SR_HARMONIZED")
+        .filterBounds(region)
+        .filterDate(start_date, end_date)
+        .filter(ee.Filter.lt("CLOUDY_PIXEL_PERCENTAGE", 20))
+        .select(gee_bands)
+    )
+
+    count = collection.size().getInfo()
+    if count == 0:
+        logger.warning(
+            "No GEE images found for %s %s to %s. Using synthetic fallback.",
+            analysis_type, start_date, end_date,
+        )
+        return _generate_synthetic_tile(
+            bbox=bbox,
+            start_date=start_date,
+            end_date=end_date,
+            analysis_type=analysis_type,
+            out_path=out_path,
+        )
+
+    image = collection.median().clip(region)
+
+    url = image.getDownloadURL({
+        "region": region,
+        "scale": scale_m,
+        "format": "GEO_TIFF",
+    })
+
+    tmp = tempfile.mktemp(suffix=".tif")
+    urllib.request.urlretrieve(url, tmp)
+
+    with rasterio.open(tmp) as src:
+        data = src.read().astype(np.float32)
+        profile = src.profile
+
+    os.unlink(tmp)
+
+    # Re-order bands to match project convention if needed
+    # (GEE returns in selection order)
+    profile.update(
+        driver="GTiff",
+        dtype="float32",
+        count=data.shape[0],
+    )
+
+    with rasterio.open(out_path, "w", **profile) as dst:
+        dst.write(data)
+
+    metadata: dict[str, Any] = {
+        "source": "gee",
+        "analysis_type": analysis_type,
+        "bbox": bbox,
+        "start_date": start_date,
+        "end_date": end_date,
+        "bands": bands,
+        "scale_m": scale_m,
+        "images_available": count,
+        "is_synthetic": False,
+        "shape": list(data.shape),
+    }
+
+    logger.info("Downloaded real tile to %s (%d images available)", out_path, count)
+    return out_path, metadata
+
+
+def _generate_synthetic_tile(
+    bbox: list[float],
+    start_date: str,
+    end_date: str,
+    analysis_type: str,
+    out_path: Path,
+) -> tuple[Path, dict[str, Any]]:
+    """
+    Generate a physically plausible synthetic Sentinel-2 tile when GEE fails.
+    The output is explicitly tagged ``is_synthetic: True``.
+    """
+    rasterio = __import__("rasterio")
+
+    bands = _get_bands_for_analysis(analysis_type)
+    n_bands = len(bands)
+    h, w = 256, 256
+
+    # Seed RNG from bbox so the same region is deterministic
+    seed = int(abs(sum(v * 1000 * (i + 1) for i, v in enumerate(bbox)))) % (2 ** 31)
+    rng = np.random.default_rng(seed)
+
+    # Build a synthetic stack: draw reflectance values typical for mixed forest
+    data = np.zeros((n_bands, h, w), dtype=np.float32)
+    for b in range(n_bands):
+        mean = rng.uniform(500.0, 3000.0)
+        std = rng.uniform(200.0, 800.0)
+        data[b] = rng.normal(mean, std, (h, w)).clip(0.0, 10000.0)
+
+    # Append an SCL band (all clear = 4)
+    scl = np.full((1, h, w), 4, dtype=np.float32)
+    data = np.concatenate([data, scl], axis=0)
+
+    transform = rasterio.transform.from_bounds(
+        bbox[0], bbox[1], bbox[2], bbox[3], w, h
+    )
+    profile = {
+        "driver": "GTiff",
+        "dtype": "float32",
+        "count": data.shape[0],
+        "height": h,
+        "width": w,
+        "crs": "EPSG:4326",
+        "transform": transform,
+    }
+
+    with rasterio.open(out_path, "w", **profile) as dst:
+        dst.write(data)
+
+    metadata: dict[str, Any] = {
+        "source": "synthetic_fallback",
+        "analysis_type": analysis_type,
+        "bbox": bbox,
+        "start_date": start_date,
+        "end_date": end_date,
+        "bands": bands,
+        "scale_m": 100,
+        "images_available": 0,
+        "is_synthetic": True,
+        "shape": list(data.shape),
+    }
+
+    logger.info("Generated synthetic fallback tile to %s", out_path)
+    return out_path, metadata

--- a/src/climatevision/data/preprocessing.py
+++ b/src/climatevision/data/preprocessing.py
@@ -1,0 +1,174 @@
+"""
+Sentinel-2 band normalization and preprocessing.
+
+Sentinel-2 L2A surface reflectance is stored as uint16 in range [0, 10000].
+We normalize each band to float32 using robust per-channel statistics derived
+from a large sample of Amazon/Congo forest and non-forest pixels.
+
+Reference band order expected throughout this project:
+  index 0 → B04 Red        (~665 nm)
+  index 1 → B03 Green      (~560 nm)
+  index 2 → B02 Blue       (~490 nm)
+  index 3 → B08 NIR        (~842 nm)
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Sentinel-2 L2A statistics computed from 50 k Amazon/Congo patches
+# Values are surface reflectance ×10000, band order [R, G, B, NIR]
+# ---------------------------------------------------------------------------
+_S2_MEAN = np.array([943.0, 1069.0, 981.0, 2734.0], dtype=np.float32)
+_S2_STD  = np.array([590.0,  547.0, 498.0, 1246.0], dtype=np.float32)
+
+# Robust (2nd–98th percentile) clip bounds to suppress sensor artefacts
+_S2_P2   = np.array([   0.0,   10.0,   0.0,  100.0], dtype=np.float32)
+_S2_P98  = np.array([2500.0, 2500.0, 2200.0, 8000.0], dtype=np.float32)
+
+
+class Sentinel2Normalizer:
+    """
+    Normalize a 4-band Sentinel-2 image to zero-mean / unit-variance float32.
+
+    Two modes:
+      - 'standard': use pre-computed global statistics (default, fast).
+      - 'dataset':  use statistics supplied via `fit()` (accurate per dataset).
+    """
+
+    def __init__(self, mode: str = "standard"):
+        assert mode in ("standard", "dataset")
+        self.mode = mode
+        self.mean: np.ndarray = _S2_MEAN.copy()
+        self.std: np.ndarray  = _S2_STD.copy()
+        self.p2: np.ndarray   = _S2_P2.copy()
+        self.p98: np.ndarray  = _S2_P98.copy()
+        self._fitted = (mode == "standard")
+
+    # ------------------------------------------------------------------
+    def fit(self, images: list[np.ndarray]) -> "Sentinel2Normalizer":
+        """Compute statistics from a list of (4, H, W) arrays."""
+        all_pixels: list[np.ndarray] = []
+        for img in images:
+            c, h, w = img.shape
+            all_pixels.append(img.reshape(c, -1))
+        stacked = np.concatenate(all_pixels, axis=1)  # (4, N)
+
+        self.mean = stacked.mean(axis=1).astype(np.float32)
+        self.std  = stacked.std(axis=1).astype(np.float32) + 1e-6
+        self.p2   = np.percentile(stacked, 2, axis=1).astype(np.float32)
+        self.p98  = np.percentile(stacked, 98, axis=1).astype(np.float32)
+        self._fitted = True
+        return self
+
+    # ------------------------------------------------------------------
+    def __call__(self, image: np.ndarray) -> np.ndarray:
+        """
+        Normalize a (4, H, W) uint16 or float32 array to float32.
+        Returns values roughly in [-3, 3].
+        """
+        if not self._fitted:
+            raise RuntimeError("Call fit() before normalizing in 'dataset' mode.")
+
+        img = image.astype(np.float32)
+
+        # 1. Clip outliers band-wise
+        for b in range(min(4, img.shape[0])):
+            img[b] = np.clip(img[b], self.p2[b], self.p98[b])
+
+        # 2. Standardize
+        for b in range(min(4, img.shape[0])):
+            img[b] = (img[b] - self.mean[b]) / self.std[b]
+
+        return img
+
+    # ------------------------------------------------------------------
+    def save(self, path: str | Path) -> None:
+        data = {
+            "mean": self.mean.tolist(),
+            "std":  self.std.tolist(),
+            "p2":   self.p2.tolist(),
+            "p98":  self.p98.tolist(),
+            "mode": self.mode,
+        }
+        Path(path).write_text(json.dumps(data, indent=2))
+
+    @classmethod
+    def load(cls, path: str | Path) -> "Sentinel2Normalizer":
+        data = json.loads(Path(path).read_text())
+        obj = cls(mode=data["mode"])
+        obj.mean = np.array(data["mean"], dtype=np.float32)
+        obj.std  = np.array(data["std"],  dtype=np.float32)
+        obj.p2   = np.array(data["p2"],   dtype=np.float32)
+        obj.p98  = np.array(data["p98"],  dtype=np.float32)
+        obj._fitted = True
+        return obj
+
+
+# ---------------------------------------------------------------------------
+# Dataset statistics helper
+# ---------------------------------------------------------------------------
+
+def apply_scl_cloud_mask(
+    image: np.ndarray,
+    scl_band: np.ndarray,
+    clear_labels: Optional[list[int]] = None,
+    fill_value: float = 0.0,
+) -> np.ndarray:
+    """
+    Mask cloudy pixels in a multi-band image using the Sentinel-2 SCL band.
+
+    Args:
+        image: Array of shape (C, H, W).
+        scl_band: Array of shape (H, W) containing Scene Classification Layer values.
+        clear_labels: SCL codes considered clear. Defaults to vegetation, bare soil,
+            water, and snow (``[4, 5, 6, 11]``).
+        fill_value: Value to replace cloudy pixels with.
+
+    Returns:
+        Cloud-masked image with the same shape as *image*.
+    """
+    if clear_labels is None:
+        clear_labels = [4, 5, 6, 11]
+
+    clear_mask = np.isin(scl_band, clear_labels)
+    masked = image.copy()
+    masked[:, ~clear_mask] = fill_value
+    return masked
+
+
+def compute_dataset_stats(
+    image_dir: str | Path,
+    max_samples: int = 500,
+) -> dict[str, list[float]]:
+    """
+    Compute per-channel mean/std from GeoTIFF images in a directory.
+    Returns a dict suitable for logging or saving as JSON.
+    """
+    import rasterio
+
+    image_dir = Path(image_dir)
+    paths = sorted(image_dir.glob("*.tif"))[:max_samples]
+    if not paths:
+        raise FileNotFoundError(f"No .tif files found in {image_dir}")
+
+    all_pixels: list[np.ndarray] = []
+    for p in paths:
+        with rasterio.open(p) as src:
+            img = src.read()  # (C, H, W)
+        all_pixels.append(img.reshape(img.shape[0], -1))
+
+    stacked = np.concatenate(all_pixels, axis=1).astype(np.float32)  # (C, N)
+    return {
+        "mean": stacked.mean(axis=1).tolist(),
+        "std":  stacked.std(axis=1).tolist(),
+        "min":  stacked.min(axis=1).tolist(),
+        "max":  stacked.max(axis=1).tolist(),
+    }

--- a/src/climatevision/data/preprocessing.py
+++ b/src/climatevision/data/preprocessing.py
@@ -138,6 +138,14 @@ def apply_scl_cloud_mask(
     if clear_labels is None:
         clear_labels = [4, 5, 6, 11]
 
+    if image.ndim != 3:
+        raise ValueError(f"image must be 3-D (C, H, W), got shape {image.shape}")
+    if scl_band.shape != image.shape[1:]:
+        raise ValueError(
+            f"scl_band shape {scl_band.shape} must match image spatial dimensions "
+            f"{image.shape[1:]}"
+        )
+
     clear_mask = np.isin(scl_band, clear_labels)
     masked = image.copy()
     masked[:, ~clear_mask] = fill_value


### PR DESCRIPTION
## Summary
Adds analysis-aware Sentinel-2 tile downloading, band mapping utilities, and SCL-based cloud masking to the data pipeline.

## Changes
- `gee_downloader.py`: download real Sentinel-2 composites from GEE per analysis_type, with explicit synthetic fallback
- `band_mapping.py`: single source of truth for analysis-specific bands and model config from config.yaml
- `preprocessing.py`: `apply_scl_cloud_mask()` for masking cloudy pixels before inference
- Wired all new modules into `data/__init__.py"
- Fixed .gitignore so src/climatevision/data/ is tracked correctly

## Checklist
- [x] GEE downloader reads correct bands from config.yaml
- [x] Synthetic fallback tagged with `is_synthetic: True`
- [x] Config loading cached via lru_cache
- [x] PR review feedback applied