### PR TITLE
feat(reports): add LLM-backed impact report generator

### DIFF
--- a/src/climatevision/reports/__init__.py
+++ b/src/climatevision/reports/__init__.py
@@ -1,0 +1,23 @@
+"""
+ClimateVision Reports Module
+
+LLM-backed natural-language reporting on top of model predictions and
+analytics outputs. Stakeholder reports combine carbon analytics, SHAP
+explanations, and fairness metadata into a single readable narrative.
+"""
+
+from .llm_reporter import (
+    ImpactReport,
+    LLMReporter,
+    ReportContext,
+    generate_impact_report,
+    render_template,
+)
+
+__all__ = [
+    "ImpactReport",
+    "LLMReporter",
+    "ReportContext",
+    "generate_impact_report",
+    "render_template",
+]

--- a/src/climatevision/reports/llm_reporter.py
+++ b/src/climatevision/reports/llm_reporter.py
@@ -1,0 +1,248 @@
+"""
+LLM-backed impact report generation for ClimateVision.
+
+`LLMReporter` turns a structured prediction record (carbon analytics,
+SHAP attributions, validation metrics, fairness flags) into a
+narrative report ready for NGOs and government stakeholders.
+
+A deterministic template-based renderer is always available so that
+the module never blocks the pipeline when an LLM provider is
+unreachable. When a provider is configured, the template output is
+used as the prompt skeleton and the LLM smooths it into prose.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+_DEFAULT_OUTPUT_DIR = _PROJECT_ROOT / "outputs" / "reports"
+
+
+@dataclass
+class ReportContext:
+    """Inputs the reporter draws on to compose an impact report."""
+
+    region: str
+    period: str
+    analysis_type: str
+    carbon: dict = field(default_factory=dict)
+    validation: dict = field(default_factory=dict)
+    shap: dict = field(default_factory=dict)
+    fairness: dict = field(default_factory=dict)
+    run_id: Optional[Union[int, str]] = None
+
+    def headline_metric(self) -> str:
+        hectares = self.carbon.get("hectares")
+        carbon_t = self.carbon.get("carbon_tonnes")
+        if hectares is not None and carbon_t is not None:
+            return (
+                f"{hectares:,.1f} hectares of {self.analysis_type.replace('_', ' ')} "
+                f"detected, equivalent to {carbon_t:,.1f} tCO2e."
+            )
+        if hectares is not None:
+            return f"{hectares:,.1f} hectares of {self.analysis_type.replace('_', ' ')} detected."
+        return f"Analysis run for {self.analysis_type} in {self.region} ({self.period})."
+
+
+@dataclass
+class ImpactReport:
+    summary: str
+    body: str
+    context: ReportContext
+    provider: str
+    generated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["context"] = asdict(self.context)
+        return d
+
+
+# Type alias for an LLM call: prompt -> completion
+LLMCallable = Callable[[str], str]
+
+
+def render_template(context: ReportContext, *, include_shap: bool = True) -> str:
+    """Deterministic Markdown template — used both as a fallback and as an LLM prompt seed."""
+
+    lines = [
+        f"# Impact Report — {context.region.title()} ({context.period})",
+        "",
+        f"**Headline:** {context.headline_metric()}",
+        "",
+        "## Carbon Analytics",
+    ]
+
+    if context.carbon:
+        for k, v in context.carbon.items():
+            lines.append(f"- **{k.replace('_', ' ').title()}**: {v}")
+    else:
+        lines.append("- _Carbon analytics not provided._")
+
+    lines += ["", "## Validation"]
+    if context.validation:
+        for k, v in context.validation.items():
+            lines.append(f"- **{k.upper()}**: {v}")
+    else:
+        lines.append("- _No validation metrics attached._")
+
+    if include_shap:
+        lines += ["", "## Explainability"]
+        if context.shap:
+            top_bands = context.shap.get("top_bands", [])
+            if top_bands:
+                bands = ", ".join(b["band"] if isinstance(b, dict) else str(b) for b in top_bands)
+                lines.append(f"- Most influential bands: {bands}")
+            for k, v in context.shap.items():
+                if k == "top_bands":
+                    continue
+                lines.append(f"- **{k.replace('_', ' ').title()}**: {v}")
+        else:
+            lines.append("- _No SHAP explanation attached._")
+
+    if context.fairness:
+        lines += ["", "## Fairness"]
+        for k, v in context.fairness.items():
+            lines.append(f"- **{k.replace('_', ' ').title()}**: {v}")
+
+    return "\n".join(lines) + "\n"
+
+
+def _build_prompt(context: ReportContext, template: str) -> str:
+    return (
+        "You are drafting a concise, factual environmental-impact report for "
+        "conservation organisations and government stakeholders.\n\n"
+        "Rules:\n"
+        "- Do not invent numbers; only restate values from the data block below.\n"
+        "- Keep tone neutral and policy-relevant; no promotional language.\n"
+        "- Output Markdown with the same section structure as the seed.\n"
+        "- Open with a 2–3 sentence executive summary.\n\n"
+        f"DATA (JSON):\n```json\n{json.dumps(asdict(context), indent=2, default=str)}\n```\n\n"
+        f"SEED:\n{template}\n\n"
+        "FINAL REPORT:\n"
+    )
+
+
+class LLMReporter:
+    """
+    Reporter with pluggable LLM backend.
+
+    Pass an `llm` callable (prompt -> string) to use a custom provider.
+    Without one, set CLIMATEVISION_LLM_PROVIDER=anthropic and
+    ANTHROPIC_API_KEY to use Anthropic's API; otherwise the template
+    renderer alone is used.
+    """
+
+    def __init__(self, llm: Optional[LLMCallable] = None) -> None:
+        self._llm = llm
+
+    def _call_llm(self, prompt: str) -> Optional[str]:
+        if self._llm is not None:
+            try:
+                return self._llm(prompt)
+            except Exception as exc:  # pragma: no cover - external call
+                logger.exception("user-provided LLM callable raised: %s", exc)
+                return None
+
+        provider = os.environ.get("CLIMATEVISION_LLM_PROVIDER", "").lower()
+        if provider == "anthropic":
+            return self._call_anthropic(prompt)
+        return None
+
+    def _call_anthropic(self, prompt: str) -> Optional[str]:  # pragma: no cover - external call
+        try:
+            import anthropic
+        except ImportError:
+            logger.warning("anthropic package not installed; using template only")
+            return None
+
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            logger.warning("ANTHROPIC_API_KEY not set; using template only")
+            return None
+
+        client = anthropic.Anthropic(api_key=api_key)
+        message = client.messages.create(
+            model=os.environ.get("CLIMATEVISION_LLM_MODEL", "claude-haiku-4-5-20251001"),
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        parts = [b.text for b in message.content if getattr(b, "type", None) == "text"]
+        return "".join(parts) if parts else None
+
+    def generate(
+        self,
+        context: ReportContext,
+        *,
+        include_shap: bool = True,
+    ) -> ImpactReport:
+        template = render_template(context, include_shap=include_shap)
+        prompt = _build_prompt(context, template)
+        llm_text = self._call_llm(prompt)
+
+        if llm_text:
+            body = llm_text.strip()
+            provider = "llm"
+        else:
+            body = template
+            provider = "template"
+
+        first_para = body.strip().split("\n\n", 1)[0]
+        summary = first_para.replace("\n", " ").strip()
+
+        return ImpactReport(
+            summary=summary,
+            body=body,
+            context=context,
+            provider=provider,
+        )
+
+
+def generate_impact_report(
+    region: str,
+    period: str,
+    analysis_type: str = "deforestation",
+    carbon: Optional[dict] = None,
+    validation: Optional[dict] = None,
+    shap: Optional[dict] = None,
+    fairness: Optional[dict] = None,
+    run_id: Optional[Union[int, str]] = None,
+    *,
+    llm: Optional[LLMCallable] = None,
+    include_shap: bool = True,
+    output_dir: Optional[Union[str, Path]] = None,
+) -> ImpactReport:
+    """High-level entry point used by the API and CLI."""
+    ctx = ReportContext(
+        region=region,
+        period=period,
+        analysis_type=analysis_type,
+        carbon=carbon or {},
+        validation=validation or {},
+        shap=shap or {},
+        fairness=fairness or {},
+        run_id=run_id,
+    )
+    report = LLMReporter(llm=llm).generate(ctx, include_shap=include_shap)
+
+    if output_dir is not None:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        base = f"{region}_{period}_impact"
+        (output_dir / f"{base}.md").write_text(report.body)
+        (output_dir / f"{base}.json").write_text(json.dumps(report.to_dict(), indent=2, default=str))
+
+    return report
+
+
+def _default_output_dir() -> Path:
+    return _DEFAULT_OUTPUT_DIR

--- a/tests/test_llm_reporter.py
+++ b/tests/test_llm_reporter.py
@@ -1,0 +1,99 @@
+"""Tests for reports.llm_reporter."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from climatevision.reports.llm_reporter import (
+    ImpactReport,
+    LLMReporter,
+    ReportContext,
+    generate_impact_report,
+    render_template,
+)
+
+
+def _ctx():
+    return ReportContext(
+        region="amazon",
+        period="2026-Q1",
+        analysis_type="deforestation",
+        carbon={"hectares": 1247.5, "carbon_tonnes": 4321.2, "ci_lower": 4000.0, "ci_upper": 4600.0},
+        validation={"iou": 0.81, "f1": 0.87},
+        shap={"top_bands": [{"band": "NIR", "importance": 0.42}, {"band": "Red", "importance": 0.31}]},
+        fairness={"score": 0.93, "disparity_regions": []},
+        run_id=12345,
+    )
+
+
+def test_headline_metric_uses_carbon_when_available():
+    text = _ctx().headline_metric()
+    assert "1,247.5 hectares" in text
+    assert "4,321.2 tCO2e" in text
+
+
+def test_template_renders_all_sections():
+    md = render_template(_ctx())
+    for heading in [
+        "# Impact Report",
+        "## Carbon Analytics",
+        "## Validation",
+        "## Explainability",
+        "## Fairness",
+    ]:
+        assert heading in md
+
+
+def test_template_skips_shap_when_disabled():
+    md = render_template(_ctx(), include_shap=False)
+    assert "## Explainability" not in md
+
+
+def test_reporter_falls_back_to_template_without_llm():
+    report = LLMReporter().generate(_ctx())
+    assert report.provider == "template"
+    assert "amazon" in report.body.lower()
+
+
+def test_reporter_uses_provided_llm_callable():
+    captured = {}
+
+    def fake_llm(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return "Executive summary line.\n\n## Carbon Analytics\n- Hectares: 1247.5\n"
+
+    report = LLMReporter(llm=fake_llm).generate(_ctx())
+    assert report.provider == "llm"
+    assert "Executive summary line." in report.summary
+    assert "amazon" in captured["prompt"].lower()
+
+
+def test_reporter_handles_llm_exception_gracefully():
+    def boom(prompt: str) -> str:
+        raise RuntimeError("provider down")
+
+    report = LLMReporter(llm=boom).generate(_ctx())
+    assert report.provider == "template"
+
+
+def test_generate_impact_report_writes_to_disk(tmp_path):
+    report = generate_impact_report(
+        region="amazon",
+        period="2026-Q1",
+        analysis_type="deforestation",
+        carbon={"hectares": 100.0, "carbon_tonnes": 350.0},
+        validation={"iou": 0.7, "f1": 0.8},
+        output_dir=tmp_path,
+    )
+    md_path = tmp_path / "amazon_2026-Q1_impact.md"
+    json_path = tmp_path / "amazon_2026-Q1_impact.json"
+
+    assert isinstance(report, ImpactReport)
+    assert md_path.exists()
+    assert json_path.exists()
+
+    payload = json.loads(json_path.read_text())
+    assert payload["context"]["region"] == "amazon"
+    assert payload["provider"] == "template"


### PR DESCRIPTION
## Summary
- Adds the new `src/climatevision/reports/` module with `LLMReporter`, `ReportContext`, and `ImpactReport` dataclasses.
- Composes natural-language stakeholder reports from carbon analytics, SHAP attributions, validation metrics, and fairness flags.
- A deterministic Markdown template renderer is always available so the pipeline never blocks on a missing LLM provider; when an LLM callable is supplied (or `CLIMATEVISION_LLM_PROVIDER=anthropic` is configured) it smooths the template into prose using the structured data block as ground truth.
- Writes a JSON sidecar alongside the Markdown so downstream tooling can ingest the report without re-parsing prose.

## Why
Sprint deliverable: "Build llm_reporter.py — generate natural-language impact reports from prediction data." Pulls together Francis's carbon analytics, the SHAP outputs from #29, and any fairness report into a single stakeholder-ready narrative.

## Test plan
- [x] `pytest tests/test_llm_reporter.py` — 7/7 pass
  - headline metric formatting with carbon hectares + tCO2e
  - template renders all required sections
  - SHAP section can be suppressed via `include_shap=False`
  - reporter falls back to template provider when no LLM is configured
  - reporter uses a user-provided LLM callable when supplied
  - reporter swallows LLM exceptions and falls back to template
  - `generate_impact_report(... output_dir=...)` writes both `.md` and `.json` to disk

## Notes for reviewers
- Branched off `develop`. New top-level `reports/` package; no existing files modified.
- Anthropic provider is a soft dependency — `import anthropic` is guarded so the module imports cleanly without it.