### PR TITLE
feat(governance): add release CI gate for metrics, fairness, and security

### DIFF
--- a/scripts/governance_ci_gate.py
+++ b/scripts/governance_ci_gate.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+"""
+Governance CI gate for ClimateVision model releases.
+
+Reads an evaluation metrics JSON, an optional fairness report, and an
+optional security scan report, and decides whether the release is
+allowed to proceed.
+
+Exit codes:
+    0   all gates passed
+    1   one or more gates failed (CI must fail the build)
+    2   bad invocation / missing inputs
+
+Threshold defaults can be overridden via --thresholds (JSON file). The
+script prints a Markdown summary of which gates passed and which
+failed; CI systems can capture this and post it back to the PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("governance_ci_gate")
+
+DEFAULT_THRESHOLDS: dict[str, Any] = {
+    "metrics": {
+        "iou": 0.70,
+        "f1": 0.75,
+    },
+    "fairness": {
+        "min_score": 0.80,
+        "max_disparity_regions": 0,
+    },
+    "security": {
+        "max_high": 0,
+        "max_critical": 0,
+    },
+}
+
+EXIT_OK = 0
+EXIT_FAIL = 1
+EXIT_BAD_INPUT = 2
+
+
+@dataclass
+class GateResult:
+    name: str
+    passed: bool
+    detail: str
+
+
+def _load_json(path: Path) -> dict:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return json.loads(path.read_text())
+
+
+def evaluate_metrics_gate(metrics: dict, thresholds: dict) -> list[GateResult]:
+    results: list[GateResult] = []
+    for metric, floor in thresholds.items():
+        value = metrics.get(metric)
+        if value is None:
+            results.append(
+                GateResult(
+                    name=f"metrics.{metric}",
+                    passed=False,
+                    detail=f"missing metric '{metric}'",
+                )
+            )
+            continue
+        passed = value >= floor
+        results.append(
+            GateResult(
+                name=f"metrics.{metric}",
+                passed=passed,
+                detail=f"value={value:.3f} threshold>={floor:.3f}",
+            )
+        )
+    return results
+
+
+def evaluate_fairness_gate(report: dict, thresholds: dict) -> list[GateResult]:
+    results: list[GateResult] = []
+    score = report.get("score")
+    if score is not None:
+        passed = score >= thresholds["min_score"]
+        results.append(
+            GateResult(
+                name="fairness.score",
+                passed=passed,
+                detail=f"score={score:.3f} threshold>={thresholds['min_score']:.3f}",
+            )
+        )
+    else:
+        results.append(
+            GateResult(
+                name="fairness.score",
+                passed=False,
+                detail="missing score",
+            )
+        )
+
+    disparity = report.get("disparity_regions") or []
+    passed = len(disparity) <= thresholds["max_disparity_regions"]
+    results.append(
+        GateResult(
+            name="fairness.disparity_regions",
+            passed=passed,
+            detail=f"count={len(disparity)} threshold<={thresholds['max_disparity_regions']}",
+        )
+    )
+    return results
+
+
+def evaluate_security_gate(report: dict, thresholds: dict) -> list[GateResult]:
+    findings = report.get("findings", [])
+    high = sum(1 for f in findings if f.get("severity") == "high")
+    critical = sum(1 for f in findings if f.get("severity") == "critical")
+
+    return [
+        GateResult(
+            name="security.high",
+            passed=high <= thresholds["max_high"],
+            detail=f"high={high} threshold<={thresholds['max_high']}",
+        ),
+        GateResult(
+            name="security.critical",
+            passed=critical <= thresholds["max_critical"],
+            detail=f"critical={critical} threshold<={thresholds['max_critical']}",
+        ),
+    ]
+
+
+def render_summary(results: list[GateResult]) -> str:
+    rows = ["| Gate | Status | Detail |", "| --- | --- | --- |"]
+    for r in results:
+        status = "PASS" if r.passed else "FAIL"
+        rows.append(f"| {r.name} | {status} | {r.detail} |")
+    overall = "PASS" if all(r.passed for r in results) else "FAIL"
+    return f"## Governance CI Gate — {overall}\n\n" + "\n".join(rows) + "\n"
+
+
+def run_gate(
+    metrics_path: Path,
+    fairness_path: Optional[Path],
+    security_path: Optional[Path],
+    thresholds: dict,
+) -> tuple[bool, list[GateResult]]:
+    results: list[GateResult] = []
+
+    metrics = _load_json(metrics_path)
+    results.extend(evaluate_metrics_gate(metrics, thresholds["metrics"]))
+
+    if fairness_path is not None:
+        fairness = _load_json(fairness_path)
+        results.extend(evaluate_fairness_gate(fairness, thresholds["fairness"]))
+
+    if security_path is not None:
+        security = _load_json(security_path)
+        results.extend(evaluate_security_gate(security, thresholds["security"]))
+
+    return all(r.passed for r in results), results
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metrics", type=Path, required=True, help="Evaluation metrics JSON")
+    parser.add_argument("--fairness", type=Path, default=None, help="Fairness report JSON")
+    parser.add_argument("--security", type=Path, default=None, help="Security scan JSON")
+    parser.add_argument("--thresholds", type=Path, default=None, help="Override thresholds JSON")
+    parser.add_argument("--summary-out", type=Path, default=None, help="Write Markdown summary")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _merge_thresholds(custom: Optional[dict]) -> dict:
+    if not custom:
+        return {k: dict(v) for k, v in DEFAULT_THRESHOLDS.items()}
+    merged: dict[str, Any] = {}
+    for section, defaults in DEFAULT_THRESHOLDS.items():
+        merged[section] = {**defaults, **(custom.get(section) or {})}
+    return merged
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    thresholds = _merge_thresholds(
+        json.loads(args.thresholds.read_text()) if args.thresholds else None
+    )
+
+    try:
+        passed, results = run_gate(
+            metrics_path=args.metrics,
+            fairness_path=args.fairness,
+            security_path=args.security,
+            thresholds=thresholds,
+        )
+    except FileNotFoundError as exc:
+        logger.error("input file missing: %s", exc)
+        return EXIT_BAD_INPUT
+
+    summary = render_summary(results)
+    print(summary)
+    if args.summary_out:
+        args.summary_out.parent.mkdir(parents=True, exist_ok=True)
+        args.summary_out.write_text(summary)
+
+    return EXIT_OK if passed else EXIT_FAIL
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_governance_ci_gate.py
+++ b/tests/test_governance_ci_gate.py
@@ -1,0 +1,116 @@
+"""Tests for scripts.governance_ci_gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_GATE_PATH = Path(__file__).resolve().parent.parent / "scripts" / "governance_ci_gate.py"
+_spec = importlib.util.spec_from_file_location("governance_ci_gate", _GATE_PATH)
+gate = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["governance_ci_gate"] = gate
+_spec.loader.exec_module(gate)
+
+
+def _good_metrics():
+    return {"iou": 0.82, "f1": 0.86, "precision": 0.88, "recall": 0.85}
+
+
+def _bad_metrics():
+    return {"iou": 0.55, "f1": 0.60}
+
+
+def _good_fairness():
+    return {"score": 0.92, "disparity_regions": []}
+
+
+def _bad_fairness():
+    return {"score": 0.5, "disparity_regions": ["amazon", "congo"]}
+
+
+def _security(high=0, critical=0):
+    findings = [{"severity": "high"}] * high + [{"severity": "critical"}] * critical
+    return {"findings": findings}
+
+
+def _write(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def test_metrics_gate_passes_when_above_threshold(tmp_path):
+    metrics_path = _write(tmp_path / "m.json", _good_metrics())
+    passed, results = gate.run_gate(metrics_path, None, None, gate._merge_thresholds(None))
+    assert passed
+    assert all(r.passed for r in results)
+
+
+def test_metrics_gate_fails_when_below_threshold(tmp_path):
+    metrics_path = _write(tmp_path / "m.json", _bad_metrics())
+    passed, _ = gate.run_gate(metrics_path, None, None, gate._merge_thresholds(None))
+    assert not passed
+
+
+def test_fairness_gate_fails_on_disparity(tmp_path):
+    metrics = _write(tmp_path / "m.json", _good_metrics())
+    fairness = _write(tmp_path / "f.json", _bad_fairness())
+    passed, results = gate.run_gate(metrics, fairness, None, gate._merge_thresholds(None))
+    assert not passed
+    failed_names = {r.name for r in results if not r.passed}
+    assert "fairness.score" in failed_names or "fairness.disparity_regions" in failed_names
+
+
+def test_security_gate_fails_on_high_finding(tmp_path):
+    metrics = _write(tmp_path / "m.json", _good_metrics())
+    security = _write(tmp_path / "s.json", _security(high=1))
+    passed, _ = gate.run_gate(metrics, None, security, gate._merge_thresholds(None))
+    assert not passed
+
+
+def test_thresholds_can_be_overridden(tmp_path):
+    metrics = _write(tmp_path / "m.json", _bad_metrics())
+    custom = {"metrics": {"iou": 0.5, "f1": 0.5}}
+    passed, _ = gate.run_gate(metrics, None, None, gate._merge_thresholds(custom))
+    assert passed
+
+
+def test_render_summary_includes_pass_and_fail():
+    results = [
+        gate.GateResult(name="a", passed=True, detail="ok"),
+        gate.GateResult(name="b", passed=False, detail="bad"),
+    ]
+    md = gate.render_summary(results)
+    assert "Governance CI Gate — FAIL" in md
+    assert "PASS" in md and "FAIL" in md
+
+
+def test_main_exits_nonzero_on_failure(tmp_path):
+    metrics = _write(tmp_path / "m.json", _bad_metrics())
+    rc = gate.main(["--metrics", str(metrics)])
+    assert rc == gate.EXIT_FAIL
+
+
+def test_main_exits_zero_on_success(tmp_path):
+    metrics = _write(tmp_path / "m.json", _good_metrics())
+    fairness = _write(tmp_path / "f.json", _good_fairness())
+    security = _write(tmp_path / "s.json", _security())
+    summary_path = tmp_path / "out" / "summary.md"
+    rc = gate.main([
+        "--metrics", str(metrics),
+        "--fairness", str(fairness),
+        "--security", str(security),
+        "--summary-out", str(summary_path),
+    ])
+    assert rc == gate.EXIT_OK
+    assert summary_path.exists()
+    assert "PASS" in summary_path.read_text()
+
+
+def test_main_exits_bad_input_on_missing_metrics(tmp_path):
+    rc = gate.main(["--metrics", str(tmp_path / "missing.json")])
+    assert rc == gate.EXIT_BAD_INPUT


### PR DESCRIPTION
## Summary
- Adds `scripts/governance_ci_gate.py` — reads an evaluation metrics JSON, an optional fairness report, and an optional security scan, and decides whether a release passes its governance thresholds.
- Exit codes: `0` pass, `1` fail (build fails), `2` bad invocation. `--summary-out` writes a Markdown summary suitable for posting back to the PR.
- Defaults: `IoU >= 0.70`, `F1 >= 0.75`, fairness score `>= 0.80`, zero high/critical security findings. Overridable via `--thresholds` JSON.

## Why
Sprint deliverable: "Implement CI gate: block releases that fail fairness or security thresholds." This is the integration point that turns the bias audit, model card, and security scan outputs into a hard release criterion.

## Test plan
- [x] `pytest tests/test_governance_ci_gate.py` — 9/9 pass
  - metrics gate passes when above threshold
  - metrics gate fails when below threshold
  - fairness gate fails on disparity regions / low score
  - security gate fails on any high finding
  - thresholds can be overridden via custom config
  - Markdown summary renders pass + fail rows correctly
  - `main()` exits non-zero on failure
  - `main()` exits zero on success and writes summary file
  - `main()` exits 2 on missing metrics file

## Notes for reviewers
- Branched off `develop`. Pure script + tests; no library imports beyond stdlib.
- Designed to be called from a GitHub Actions step before the release tag is pushed: `python scripts/governance_ci_gate.py --metrics ... --fairness ... --security ...`.