### PR TITLE
feat(inference): add parallel batch processor with per-job tracking

### DIFF
--- a/src/climatevision/inference/__init__.py
+++ b/src/climatevision/inference/__init__.py
@@ -7,9 +7,17 @@ from .pipeline import (
     run_inference_from_file,
     run_inference_from_gee,
 )
+from .batch_processor import (
+    BatchJob,
+    BatchProcessor,
+    BatchSummary,
+)
 
 __all__ = [
     "run_inference",
     "run_inference_from_file",
     "run_inference_from_gee",
+    "BatchJob",
+    "BatchProcessor",
+    "BatchSummary",
 ]

--- a/src/climatevision/inference/batch_processor.py
+++ b/src/climatevision/inference/batch_processor.py
@@ -1,0 +1,209 @@
+"""
+Batch processor for ClimateVision inference jobs.
+
+Submits a list of image paths (or numpy arrays) to the inference
+pipeline in parallel, tracks per-job state, and produces a structured
+result manifest. The processor is designed to be driven from either
+a CLI script or the FastAPI background-task layer.
+
+Job state machine:
+
+    queued -> running -> (succeeded | failed)
+
+Each job is appended to a JSONL manifest as soon as its terminal
+state is reached so a long-running batch can be resumed or audited
+without waiting for the whole queue to finish.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_DEFAULT_MANIFEST = _PROJECT_ROOT / "outputs" / "batches" / "manifest.jsonl"
+
+JobInput = Union[str, Path, dict]
+InferenceFn = Callable[[JobInput, str], dict]
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class BatchJob:
+    job_id: str
+    source: str
+    analysis_type: str
+    status: str = "queued"
+    submitted_at: str = field(default_factory=_utcnow)
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    duration_ms: Optional[int] = None
+    result_summary: Optional[dict] = None
+    error: Optional[str] = None
+    attempts: int = 0
+
+
+@dataclass
+class BatchSummary:
+    total: int
+    succeeded: int
+    failed: int
+    duration_seconds: float
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _default_inference_fn(source: JobInput, analysis_type: str) -> dict:
+    """
+    Default inference adapter — calls run_inference_from_file or run_inference
+    depending on the input shape. Imported lazily so unit tests can stub it.
+    """
+    from climatevision.inference.pipeline import (
+        run_inference,
+        run_inference_from_file,
+    )
+
+    if isinstance(source, (str, Path)):
+        return run_inference_from_file(str(source), analysis_type=analysis_type)
+    if isinstance(source, dict):
+        return run_inference(**source, analysis_type=analysis_type)
+    raise TypeError(f"Unsupported source type: {type(source).__name__}")
+
+
+class BatchProcessor:
+    """
+    Parallel batch executor for inference jobs.
+
+    Args:
+        max_workers: Thread pool size. Defaults to 4.
+        max_attempts: Retry count for transient failures.
+        manifest_path: Where to append per-job records. Created on first write.
+        inference_fn: Override the actual inference call (handy for tests
+            and for swapping in batch_predict implementations later).
+    """
+
+    def __init__(
+        self,
+        max_workers: int = 4,
+        max_attempts: int = 1,
+        manifest_path: Optional[Union[str, Path]] = None,
+        inference_fn: Optional[InferenceFn] = None,
+    ) -> None:
+        self.max_workers = max_workers
+        self.max_attempts = max(1, max_attempts)
+        self.manifest_path = Path(manifest_path) if manifest_path else _DEFAULT_MANIFEST
+        self._inference_fn = inference_fn or _default_inference_fn
+        self._jobs: dict[str, BatchJob] = {}
+        self._lock = threading.Lock()
+
+    def _persist(self, job: BatchJob) -> None:
+        self.manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._lock, self.manifest_path.open("a") as fh:
+            fh.write(json.dumps(asdict(job)) + "\n")
+
+    def _summarize_result(self, result: Any) -> dict:
+        if isinstance(result, dict):
+            keep = {}
+            for key in ("hectares", "carbon_tonnes", "iou", "f1", "mean_confidence"):
+                if key in result:
+                    keep[key] = result[key]
+            if "mask" in result:
+                import numpy as np
+
+                arr = np.asarray(result["mask"])
+                keep["positive_pixels"] = int(arr.sum())
+                keep["total_pixels"] = int(arr.size)
+            return keep
+        return {"raw": str(result)[:200]}
+
+    def _run_one(self, job: BatchJob, source: JobInput) -> BatchJob:
+        for attempt in range(1, self.max_attempts + 1):
+            job.attempts = attempt
+            job.status = "running"
+            job.started_at = _utcnow()
+            t0 = time.perf_counter()
+            try:
+                result = self._inference_fn(source, job.analysis_type)
+                job.result_summary = self._summarize_result(result)
+                job.status = "succeeded"
+                job.error = None
+                break
+            except Exception as exc:  # noqa: BLE001 - we want to capture all
+                logger.exception("Job %s attempt %d failed", job.job_id, attempt)
+                job.error = f"{type(exc).__name__}: {exc}"
+                job.status = "failed"
+            finally:
+                job.duration_ms = int((time.perf_counter() - t0) * 1000)
+                job.finished_at = _utcnow()
+        self._persist(job)
+        return job
+
+    def submit_batch(
+        self,
+        sources: Iterable[JobInput],
+        analysis_type: str = "deforestation",
+    ) -> list[BatchJob]:
+        sources = list(sources)
+        jobs = [
+            BatchJob(
+                job_id=str(uuid.uuid4()),
+                source=str(s) if isinstance(s, (str, Path)) else json.dumps(s, default=str),
+                analysis_type=analysis_type,
+            )
+            for s in sources
+        ]
+        for j in jobs:
+            self._jobs[j.job_id] = j
+        return jobs
+
+    def run(
+        self,
+        sources: Iterable[JobInput],
+        analysis_type: str = "deforestation",
+    ) -> tuple[list[BatchJob], BatchSummary]:
+        sources = list(sources)
+        jobs = self.submit_batch(sources, analysis_type=analysis_type)
+        t0 = time.perf_counter()
+
+        with ThreadPoolExecutor(max_workers=self.max_workers) as pool:
+            futures = {
+                pool.submit(self._run_one, job, source): job
+                for job, source in zip(jobs, sources)
+            }
+            for fut in as_completed(futures):
+                fut.result()
+
+        duration = time.perf_counter() - t0
+        succeeded = sum(1 for j in jobs if j.status == "succeeded")
+        failed = sum(1 for j in jobs if j.status == "failed")
+        summary = BatchSummary(
+            total=len(jobs),
+            succeeded=succeeded,
+            failed=failed,
+            duration_seconds=round(duration, 3),
+        )
+        logger.info(
+            "Batch finished: total=%d succeeded=%d failed=%d in %.2fs",
+            summary.total,
+            summary.succeeded,
+            summary.failed,
+            duration,
+        )
+        return jobs, summary
+
+    def get_job(self, job_id: str) -> Optional[BatchJob]:
+        return self._jobs.get(job_id)

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -1,0 +1,144 @@
+"""Tests for inference.batch_processor.
+
+Imports the module directly via importlib to avoid the
+``climatevision.inference`` package __init__ pulling in the rest of the
+inference pipeline at test-collection time. Once the data package
+__init__ is repaired we can drop the importlib shim.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_BATCH_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "climatevision"
+    / "inference"
+    / "batch_processor.py"
+)
+_spec = importlib.util.spec_from_file_location("cv_batch_processor", _BATCH_PATH)
+batch = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["cv_batch_processor"] = batch
+_spec.loader.exec_module(batch)
+
+BatchProcessor = batch.BatchProcessor
+BatchSummary = batch.BatchSummary
+
+
+def _ok_inference(source, analysis_type):
+    return {
+        "hectares": 10.0,
+        "carbon_tonnes": 35.0,
+        "mean_confidence": 0.82,
+        "mask": np.ones((4, 4), dtype=np.uint8),
+    }
+
+
+def _flaky_inference(state):
+    def _fn(source, analysis_type):
+        state["calls"] += 1
+        if state["calls"] < 2:
+            raise RuntimeError("transient")
+        return {"hectares": 1.0, "carbon_tonnes": 3.0}
+    return _fn
+
+
+def _always_fail(source, analysis_type):
+    raise ValueError(f"bad source: {source}")
+
+
+def test_run_succeeds_for_all_jobs(tmp_path):
+    proc = BatchProcessor(
+        max_workers=2,
+        manifest_path=tmp_path / "manifest.jsonl",
+        inference_fn=_ok_inference,
+    )
+    jobs, summary = proc.run(["a.tif", "b.tif", "c.tif"])
+
+    assert summary.total == 3
+    assert summary.succeeded == 3
+    assert summary.failed == 0
+    assert all(j.status == "succeeded" for j in jobs)
+    assert all(j.duration_ms is not None and j.duration_ms >= 0 for j in jobs)
+    assert all(j.attempts == 1 for j in jobs)
+
+
+def test_failed_jobs_are_isolated(tmp_path):
+    proc = BatchProcessor(
+        max_workers=2,
+        manifest_path=tmp_path / "manifest.jsonl",
+        inference_fn=_always_fail,
+    )
+    jobs, summary = proc.run(["a.tif", "b.tif"])
+
+    assert summary.failed == 2
+    assert summary.succeeded == 0
+    assert all(j.status == "failed" and j.error.startswith("ValueError") for j in jobs)
+
+
+def test_retry_succeeds_after_transient_failure(tmp_path):
+    state = {"calls": 0}
+    proc = BatchProcessor(
+        max_workers=1,
+        max_attempts=3,
+        manifest_path=tmp_path / "manifest.jsonl",
+        inference_fn=_flaky_inference(state),
+    )
+    jobs, summary = proc.run(["only.tif"])
+    assert summary.succeeded == 1
+    assert jobs[0].attempts == 2
+
+
+def test_manifest_records_each_job(tmp_path):
+    manifest = tmp_path / "manifest.jsonl"
+    proc = BatchProcessor(
+        max_workers=2,
+        manifest_path=manifest,
+        inference_fn=_ok_inference,
+    )
+    proc.run(["a.tif", "b.tif"])
+
+    lines = [json.loads(l) for l in manifest.read_text().splitlines() if l.strip()]
+    assert len(lines) == 2
+    statuses = {l["status"] for l in lines}
+    assert statuses == {"succeeded"}
+    for line in lines:
+        assert line["result_summary"]["hectares"] == 10.0
+        assert line["result_summary"]["positive_pixels"] == 16
+
+
+def test_get_job_returns_record(tmp_path):
+    proc = BatchProcessor(
+        manifest_path=tmp_path / "manifest.jsonl",
+        inference_fn=_ok_inference,
+    )
+    jobs, _ = proc.run(["a.tif"])
+    fetched = proc.get_job(jobs[0].job_id)
+    assert fetched is not None
+    assert fetched.status == "succeeded"
+
+
+def test_dict_source_roundtrips(tmp_path):
+    captured = {}
+
+    def fn(source, analysis_type):
+        captured["source"] = source
+        captured["analysis_type"] = analysis_type
+        return {"hectares": 0.0, "carbon_tonnes": 0.0}
+
+    proc = BatchProcessor(
+        manifest_path=tmp_path / "manifest.jsonl",
+        inference_fn=fn,
+    )
+    jobs, summary = proc.run([{"bbox": [0, 0, 1, 1], "date": "2026-01-01"}], analysis_type="flooding")
+    assert summary.succeeded == 1
+    assert captured["analysis_type"] == "flooding"
+    assert captured["source"]["bbox"] == [0, 0, 1, 1]


### PR DESCRIPTION
## Summary
- Adds `src/climatevision/inference/batch_processor.py` — `BatchProcessor` runs inference over a list of sources in parallel via a thread pool.
- Per-job state machine: `queued -> running -> succeeded | failed`. Records timing (`duration_ms`), `attempts`, and any captured error message.
- Each terminal job is appended to a JSONL manifest as soon as it finishes, so long-running batches can be resumed or audited without waiting for the whole queue to finish.
- Configurable retry (`max_attempts`) handles transient failures.
- Injectable `inference_fn` lets the API layer swap in a batch-friendly implementation later without changing the orchestration code.

## Why
Sprint deliverable: "Build batch_processor.py — parallel image processing with per-job status tracking." Foundation for the upcoming `/api/jobs` admin endpoints and the alert-generator.

## Test plan
- [x] `pytest tests/test_batch_processor.py` — 6/6 pass
  - all jobs succeed when the inference fn is healthy
  - failures are isolated per job (one bad job does not stop others)
  - retry succeeds after a transient failure on attempt 1
  - manifest captures every terminal job with the right summary fields
  - `get_job(job_id)` returns the cached record
  - dict-shaped sources are round-tripped to the inference fn with the right analysis_type

## Notes for reviewers
- Branched off `develop`. The test imports `batch_processor.py` via `importlib` to avoid the broken `climatevision.data.__init__` (which references unmerged modules `dataset`, `augmentation`, `synthetic`). Worth a separate cleanup PR; not in scope here.
- Default manifest path: `outputs/batches/manifest.jsonl`. Override via `BatchProcessor(manifest_path=...)`.
- `_default_inference_fn` lazy-imports `pipeline.run_inference` so callers that bring their own `inference_fn` do not pay the cost of loading the model registry.