### PR TITLE
feat(inference): add subscription-driven deforestation alert generator

### DIFF
--- a/src/climatevision/inference/alert_generator.py
+++ b/src/climatevision/inference/alert_generator.py
@@ -1,0 +1,229 @@
+"""
+Deforestation alert generator for ClimateVision.
+
+Watches for inference results that exceed a configurable threshold for
+a given subscription (region, analysis_type, alert_threshold) and emits
+notifications via pluggable channels (email, webhook, log).
+
+Routing rules:
+
+- Each `Subscription` defines a region (bbox), analysis type, threshold,
+  and a list of channels to deliver to.
+- A new prediction is matched against subscriptions by analysis type
+  and whether its bbox overlaps the subscription bbox.
+- Alerts are de-duplicated within a configurable cooldown window so a
+  flapping signal does not page everyone every minute.
+
+The generator does not perform delivery itself for non-loggable channels;
+it returns delivery records that the caller (typically the alert worker
+or `notification_router.deliver_pending`) is responsible for sending.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Iterable, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_DEFAULT_ALERT_LOG = _PROJECT_ROOT / "outputs" / "alerts" / "alerts.jsonl"
+
+DeliveryFn = Callable[["Alert"], None]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class Subscription:
+    org_id: int
+    bbox: tuple[float, float, float, float]
+    analysis_type: str
+    alert_threshold: float
+    channels: tuple[str, ...] = ("log",)
+    cooldown_minutes: int = 60
+
+
+@dataclass
+class Alert:
+    alert_id: str
+    org_id: int
+    analysis_type: str
+    region_bbox: tuple[float, float, float, float]
+    severity: str
+    measured_value: float
+    threshold: float
+    summary: str
+    triggered_at: str
+    channels: tuple[str, ...]
+
+
+def _bbox_overlaps(
+    a: tuple[float, float, float, float],
+    b: tuple[float, float, float, float],
+) -> bool:
+    a_min_x, a_min_y, a_max_x, a_max_y = a
+    b_min_x, b_min_y, b_max_x, b_max_y = b
+    return not (
+        a_max_x < b_min_x
+        or b_max_x < a_min_x
+        or a_max_y < b_min_y
+        or b_max_y < a_min_y
+    )
+
+
+def _classify_severity(measured: float, threshold: float) -> str:
+    if measured >= threshold * 3:
+        return "critical"
+    if measured >= threshold * 2:
+        return "high"
+    return "medium"
+
+
+class AlertGenerator:
+    """
+    Subscription-driven alert generator with cooldown deduplication.
+    """
+
+    def __init__(
+        self,
+        subscriptions: Optional[Iterable[Subscription]] = None,
+        alert_log_path: Optional[Union[str, Path]] = None,
+        delivery: Optional[dict[str, DeliveryFn]] = None,
+        clock: Callable[[], datetime] = _utcnow,
+    ) -> None:
+        self._subscriptions: list[Subscription] = list(subscriptions or [])
+        self.alert_log_path = Path(alert_log_path) if alert_log_path else _DEFAULT_ALERT_LOG
+        self._delivery = dict(delivery or {})
+        self._lock = threading.Lock()
+        self._last_fired: dict[tuple[int, str], datetime] = {}
+        self._clock = clock
+
+    def add_subscription(self, sub: Subscription) -> None:
+        self._subscriptions.append(sub)
+
+    def register_channel(self, name: str, fn: DeliveryFn) -> None:
+        self._delivery[name] = fn
+
+    def _persist(self, alert: Alert) -> None:
+        self.alert_log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._lock, self.alert_log_path.open("a") as fh:
+            fh.write(json.dumps(asdict(alert)) + "\n")
+
+    def _in_cooldown(self, sub: Subscription, now: datetime) -> bool:
+        key = (sub.org_id, sub.analysis_type)
+        last = self._last_fired.get(key)
+        if last is None:
+            return False
+        return now - last < timedelta(minutes=sub.cooldown_minutes)
+
+    def _matches(
+        self,
+        sub: Subscription,
+        analysis_type: str,
+        bbox: tuple[float, float, float, float],
+        measured_value: float,
+    ) -> bool:
+        if sub.analysis_type != analysis_type:
+            return False
+        if not _bbox_overlaps(sub.bbox, bbox):
+            return False
+        return measured_value >= sub.alert_threshold
+
+    def evaluate(
+        self,
+        analysis_type: str,
+        bbox: tuple[float, float, float, float],
+        measured_value: float,
+        summary: str = "",
+    ) -> list[Alert]:
+        now = self._clock()
+        alerts: list[Alert] = []
+
+        for sub in self._subscriptions:
+            if not self._matches(sub, analysis_type, bbox, measured_value):
+                continue
+            if self._in_cooldown(sub, now):
+                logger.debug(
+                    "Skipping alert for org=%s in cooldown", sub.org_id
+                )
+                continue
+
+            alert = Alert(
+                alert_id=str(uuid.uuid4()),
+                org_id=sub.org_id,
+                analysis_type=analysis_type,
+                region_bbox=bbox,
+                severity=_classify_severity(measured_value, sub.alert_threshold),
+                measured_value=float(measured_value),
+                threshold=float(sub.alert_threshold),
+                summary=summary or (
+                    f"{analysis_type} signal {measured_value:.3f} "
+                    f"exceeded threshold {sub.alert_threshold:.3f}"
+                ),
+                triggered_at=now.isoformat(),
+                channels=tuple(sub.channels),
+            )
+            self._last_fired[(sub.org_id, sub.analysis_type)] = now
+            self._persist(alert)
+            self._dispatch(alert)
+            alerts.append(alert)
+
+        if alerts:
+            logger.info("Fired %d alert(s) for analysis=%s", len(alerts), analysis_type)
+        return alerts
+
+    def _dispatch(self, alert: Alert) -> None:
+        for channel in alert.channels:
+            fn = self._delivery.get(channel)
+            if fn is None:
+                logger.warning(
+                    "No delivery handler registered for channel '%s' (alert=%s)",
+                    channel,
+                    alert.alert_id,
+                )
+                continue
+            try:
+                fn(alert)
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Delivery on channel '%s' failed for alert=%s",
+                    channel,
+                    alert.alert_id,
+                )
+
+    def iter_alerts(self) -> list[Alert]:
+        if not self.alert_log_path.exists():
+            return []
+        out: list[Alert] = []
+        with self.alert_log_path.open() as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                row = json.loads(line)
+                row["region_bbox"] = tuple(row["region_bbox"])
+                row["channels"] = tuple(row["channels"])
+                out.append(Alert(**row))
+        return out
+
+
+def log_channel(alert: Alert) -> None:
+    """Default 'log' channel — writes the alert summary at WARNING level."""
+    logger.warning(
+        "ALERT [%s] org=%s analysis=%s severity=%s value=%.3f >= %.3f :: %s",
+        alert.alert_id,
+        alert.org_id,
+        alert.analysis_type,
+        alert.severity,
+        alert.measured_value,
+        alert.threshold,
+        alert.summary,
+    )

--- a/tests/test_alert_generator.py
+++ b/tests/test_alert_generator.py
@@ -1,0 +1,165 @@
+"""Tests for inference.alert_generator.
+
+Imports the module via importlib to avoid the broken
+``climatevision.inference.__init__`` -> data package chain.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "climatevision"
+    / "inference"
+    / "alert_generator.py"
+)
+_spec = importlib.util.spec_from_file_location("cv_alert_generator", _PATH)
+ag = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["cv_alert_generator"] = ag
+_spec.loader.exec_module(ag)
+
+
+def _amazon_subscription(**overrides):
+    base = dict(
+        org_id=1,
+        bbox=(-60.0, -15.0, -45.0, 5.0),
+        analysis_type="deforestation",
+        alert_threshold=0.15,
+        channels=("log",),
+        cooldown_minutes=60,
+    )
+    base.update(overrides)
+    return ag.Subscription(**base)
+
+
+def _frozen_clock(start: datetime):
+    state = {"now": start}
+
+    def clock():
+        return state["now"]
+
+    def advance(minutes: int):
+        state["now"] = state["now"] + timedelta(minutes=minutes)
+
+    return clock, advance
+
+
+def test_alert_fires_when_threshold_exceeded(tmp_path):
+    gen = ag.AlertGenerator(
+        subscriptions=[_amazon_subscription()],
+        alert_log_path=tmp_path / "alerts.jsonl",
+        delivery={"log": ag.log_channel},
+    )
+    alerts = gen.evaluate(
+        analysis_type="deforestation",
+        bbox=(-55.0, -10.0, -50.0, 0.0),
+        measured_value=0.30,
+    )
+    assert len(alerts) == 1
+    assert alerts[0].severity == "high"  # 0.30 >= 0.15 * 2
+    assert alerts[0].channels == ("log",)
+
+
+def test_no_alert_below_threshold(tmp_path):
+    gen = ag.AlertGenerator(
+        subscriptions=[_amazon_subscription()],
+        alert_log_path=tmp_path / "alerts.jsonl",
+    )
+    alerts = gen.evaluate(
+        analysis_type="deforestation",
+        bbox=(-55.0, -10.0, -50.0, 0.0),
+        measured_value=0.10,
+    )
+    assert alerts == []
+
+
+def test_subscription_filtered_by_analysis_type(tmp_path):
+    gen = ag.AlertGenerator(
+        subscriptions=[_amazon_subscription()],
+        alert_log_path=tmp_path / "alerts.jsonl",
+    )
+    alerts = gen.evaluate(
+        analysis_type="flooding",
+        bbox=(-55.0, -10.0, -50.0, 0.0),
+        measured_value=0.99,
+    )
+    assert alerts == []
+
+
+def test_subscription_filtered_by_bbox_overlap(tmp_path):
+    gen = ag.AlertGenerator(
+        subscriptions=[_amazon_subscription()],
+        alert_log_path=tmp_path / "alerts.jsonl",
+    )
+    # Disjoint bbox over Africa
+    alerts = gen.evaluate(
+        analysis_type="deforestation",
+        bbox=(20.0, 0.0, 30.0, 10.0),
+        measured_value=0.99,
+    )
+    assert alerts == []
+
+
+def test_cooldown_suppresses_duplicates(tmp_path):
+    start = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    clock, advance = _frozen_clock(start)
+    gen = ag.AlertGenerator(
+        subscriptions=[_amazon_subscription(cooldown_minutes=30)],
+        alert_log_path=tmp_path / "alerts.jsonl",
+        clock=clock,
+    )
+    first = gen.evaluate("deforestation", (-55.0, -10.0, -50.0, 0.0), 0.30)
+    advance(10)
+    second = gen.evaluate("deforestation", (-55.0, -10.0, -50.0, 0.0), 0.30)
+    advance(40)
+    third = gen.evaluate("deforestation", (-55.0, -10.0, -50.0, 0.0), 0.30)
+
+    assert len(first) == 1
+    assert second == []
+    assert len(third) == 1
+
+
+def test_severity_escalation():
+    assert ag._classify_severity(0.20, 0.15) == "medium"
+    assert ag._classify_severity(0.31, 0.15) == "high"
+    assert ag._classify_severity(0.46, 0.15) == "critical"
+
+
+def test_custom_channel_delivery_called(tmp_path):
+    delivered: list = []
+
+    def fake_webhook(alert):
+        delivered.append(alert.alert_id)
+
+    sub = _amazon_subscription(channels=("webhook",))
+    gen = ag.AlertGenerator(
+        subscriptions=[sub],
+        alert_log_path=tmp_path / "alerts.jsonl",
+        delivery={"webhook": fake_webhook},
+    )
+    alerts = gen.evaluate("deforestation", (-55.0, -10.0, -50.0, 0.0), 0.30)
+    assert len(delivered) == 1
+    assert delivered[0] == alerts[0].alert_id
+
+
+def test_persisted_alerts_can_be_replayed(tmp_path):
+    path = tmp_path / "alerts.jsonl"
+    gen = ag.AlertGenerator(
+        subscriptions=[_amazon_subscription()],
+        alert_log_path=path,
+    )
+    gen.evaluate("deforestation", (-55.0, -10.0, -50.0, 0.0), 0.30)
+
+    fresh = ag.AlertGenerator(alert_log_path=path)
+    replayed = fresh.iter_alerts()
+    assert len(replayed) == 1
+    assert replayed[0].severity in {"medium", "high", "critical"}


### PR DESCRIPTION
## Summary
- Adds `src/climatevision/inference/alert_generator.py` — `AlertGenerator` matches inference results against per-organisation `Subscription` records (region bbox + analysis_type + threshold) and fires alerts when the measured value crosses the threshold.
- Per-subscription **cooldown** windows deduplicate flapping signals so a flapping pixel does not page the same NGO every minute.
- Severity is classified `medium` / `high` / `critical` based on how far the value is past the threshold (1x / 2x / 3x).
- **Pluggable channels**: register delivery callables per channel name (`log`, `email`, `webhook`, ...). Default `log_channel` ships in the module; email/webhook implementations are out of scope here and slot in via `register_channel()`.
- Every fired alert is persisted to a JSONL log for replay and audit; `iter_alerts()` reads it back.

## Why
Sprint deliverable: "Build alert_generator.py — configurable deforestation threshold alerting" + "Implement notification routing (email, webhook) for triggered alerts." This PR ships the core router; the email and webhook channel implementations will land separately on top of #10 (alert delivery worker).

## Test plan
- [x] `pytest tests/test_alert_generator.py` — 8/8 pass
  - alert fires when threshold is exceeded
  - no alert below threshold
  - subscriptions filtered by analysis_type
  - subscriptions filtered by bbox overlap
  - cooldown suppresses duplicates inside the window, allows them after
  - severity escalation (medium / high / critical) at 1x / 2x / 3x threshold
  - custom channel delivery callables are invoked exactly once per fired alert
  - persisted alerts are replayed correctly by a fresh AlertGenerator

## Notes for reviewers
- Branched off `develop`. Does not modify `inference/__init__.py` so it does not conflict with PR #40 (batch processor); rebase order is flexible.
- bbox uses `(min_x, min_y, max_x, max_y)` (xmin, ymin, xmax, ymax). Matches the existing `PredictRequest.bbox` convention from `api/schemas.py`.
- Cooldown is keyed on `(org_id, analysis_type)`. If we later need region-keyed cooldown that can be added without breaking the public API.