### PR TITLE
feat(api): add /api/reports and /api/anomalies admin endpoints

### DIFF
--- a/src/climatevision/api/admin.py
+++ b/src/climatevision/api/admin.py
@@ -1,0 +1,199 @@
+"""
+Admin endpoints for ClimateVision operational reporting.
+
+Exposes two read-only endpoints intended for the operational dashboard
+and on-call tooling:
+
+- ``GET /api/reports`` — data-quality KPIs for a configurable time window
+  (run count, error rate, mean confidence, alert count).
+- ``GET /api/anomalies`` — list of flagged anomaly predictions, optionally
+  filtered by severity and time window.
+
+Both endpoints read from JSONL files written by the audit logger and the
+anomaly detector. They never mutate state and never expose raw input
+payloads — only summary fields safe for an operations dashboard.
+
+The router is wired into the FastAPI app via ``include_router(admin.router)``
+in ``api/main.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_AUDIT_LOG = _PROJECT_ROOT / "outputs" / "audit" / "predictions.jsonl"
+DEFAULT_ANOMALY_LOG = _PROJECT_ROOT / "outputs" / "anomalies" / "history.jsonl"
+DEFAULT_ALERT_LOG = _PROJECT_ROOT / "outputs" / "alerts" / "alerts.jsonl"
+
+
+router = APIRouter(prefix="/api", tags=["admin"])
+
+
+class ReportSummary(BaseModel):
+    window_hours: int = Field(..., description="Time window in hours")
+    run_count: int = Field(..., description="Predictions logged in window")
+    error_rate: float = Field(..., description="Fraction of runs with non-OK status")
+    mean_confidence: Optional[float] = Field(None, description="Mean confidence over window")
+    positive_fraction_mean: Optional[float] = Field(None)
+    alert_count: int = Field(0, description="Alerts fired in window")
+    generated_at: str
+
+
+class AnomalyRecord(BaseModel):
+    triggered_at: Optional[str] = None
+    severity: Optional[str] = None
+    method: Optional[str] = None
+    score: Optional[float] = None
+    reasons: list[str] = Field(default_factory=list)
+    summary: Optional[str] = None
+
+
+class AnomalyList(BaseModel):
+    count: int
+    anomalies: list[AnomalyRecord]
+
+
+def _read_jsonl(path: Path) -> Iterator[dict]:
+    if not path.exists():
+        return iter(())
+    def _it() -> Iterator[dict]:
+        with path.open() as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("skipping malformed line in %s", path)
+    return _it()
+
+
+def _parse_timestamp(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        ts = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts
+
+
+def _within_window(ts: Optional[datetime], cutoff: datetime) -> bool:
+    return ts is not None and ts >= cutoff
+
+
+def build_report_summary(
+    window_hours: int,
+    audit_log: Optional[Path] = None,
+    alert_log: Optional[Path] = None,
+    now: Optional[datetime] = None,
+) -> ReportSummary:
+    if window_hours <= 0:
+        raise ValueError("window_hours must be positive")
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=window_hours)
+    audit_log = audit_log or DEFAULT_AUDIT_LOG
+    alert_log = alert_log or DEFAULT_ALERT_LOG
+
+    runs = []
+    for row in _read_jsonl(audit_log):
+        ts = _parse_timestamp(row.get("timestamp"))
+        if _within_window(ts, cutoff):
+            runs.append(row)
+
+    confidence_values = [
+        r["output_summary"]["mean_confidence"]
+        for r in runs
+        if isinstance(r.get("output_summary"), dict)
+        and r["output_summary"].get("mean_confidence") is not None
+    ]
+    positive_values = [
+        r["output_summary"]["positive_fraction"]
+        for r in runs
+        if isinstance(r.get("output_summary"), dict)
+        and r["output_summary"].get("positive_fraction") is not None
+    ]
+    error_count = sum(1 for r in runs if r.get("error"))
+
+    alerts = [
+        row
+        for row in _read_jsonl(alert_log)
+        if _within_window(_parse_timestamp(row.get("triggered_at")), cutoff)
+    ]
+
+    return ReportSummary(
+        window_hours=window_hours,
+        run_count=len(runs),
+        error_rate=(error_count / len(runs)) if runs else 0.0,
+        mean_confidence=(
+            sum(confidence_values) / len(confidence_values) if confidence_values else None
+        ),
+        positive_fraction_mean=(
+            sum(positive_values) / len(positive_values) if positive_values else None
+        ),
+        alert_count=len(alerts),
+        generated_at=now.isoformat(),
+    )
+
+
+def list_anomalies(
+    severity: Optional[str] = None,
+    window_hours: Optional[int] = None,
+    alert_log: Optional[Path] = None,
+    now: Optional[datetime] = None,
+) -> AnomalyList:
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=window_hours) if window_hours else None
+    alert_log = alert_log or DEFAULT_ALERT_LOG
+
+    out: list[AnomalyRecord] = []
+    for row in _read_jsonl(alert_log):
+        if severity and row.get("severity") != severity:
+            continue
+        ts = _parse_timestamp(row.get("triggered_at"))
+        if cutoff is not None and not _within_window(ts, cutoff):
+            continue
+        out.append(
+            AnomalyRecord(
+                triggered_at=row.get("triggered_at"),
+                severity=row.get("severity"),
+                method=row.get("method"),
+                score=row.get("score"),
+                reasons=row.get("reasons") or [],
+                summary=row.get("summary"),
+            )
+        )
+    return AnomalyList(count=len(out), anomalies=out)
+
+
+@router.get("/reports", response_model=ReportSummary)
+def get_reports(
+    window_hours: int = Query(24, gt=0, le=24 * 30 * 6),
+) -> ReportSummary:
+    """Data-quality KPIs over a configurable time window."""
+    try:
+        return build_report_summary(window_hours=window_hours)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.get("/anomalies", response_model=AnomalyList)
+def get_anomalies(
+    severity: Optional[str] = Query(None, pattern="^(low|medium|high|critical)$"),
+    window_hours: Optional[int] = Query(None, gt=0, le=24 * 30 * 6),
+) -> AnomalyList:
+    """List flagged anomaly/alert records, optionally filtered."""
+    return list_anomalies(severity=severity, window_hours=window_hours)

--- a/src/climatevision/api/main.py
+++ b/src/climatevision/api/main.py
@@ -400,6 +400,9 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
+    from climatevision.api import admin as _admin
+    app.include_router(_admin.router)
+
     # ===== Core Endpoints =====
 
     @app.get("/")

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -1,0 +1,151 @@
+"""Tests for api.admin operational endpoints.
+
+Imports the admin module via importlib to avoid the broken
+``climatevision.data`` package __init__ chain (irrelevant to admin).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "climatevision"
+    / "api"
+    / "admin.py"
+)
+_spec = importlib.util.spec_from_file_location("cv_api_admin", _PATH)
+admin = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["cv_api_admin"] = admin
+_spec.loader.exec_module(admin)
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    audit = tmp_path / "audit.jsonl"
+    alerts = tmp_path / "alerts.jsonl"
+    monkeypatch.setattr(admin, "DEFAULT_AUDIT_LOG", audit)
+    monkeypatch.setattr(admin, "DEFAULT_ALERT_LOG", alerts)
+    return audit, alerts
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def _write_audit(path, entries):
+    with path.open("a") as fh:
+        for e in entries:
+            fh.write(json.dumps(e) + "\n")
+
+
+def _make_audit_entry(minutes_ago: int, mean_conf: float, positive: float, error: bool = False):
+    ts = _now() - timedelta(minutes=minutes_ago)
+    return {
+        "timestamp": ts.isoformat(),
+        "model_version": "v1",
+        "input_hash": "abc",
+        "output_summary": {"mean_confidence": mean_conf, "positive_fraction": positive},
+        "request_id": None,
+        "user_id": None,
+        "prev_hash": "0" * 64,
+        "entry_hash": "x",
+        "metadata": {},
+        **({"error": "boom"} if error else {}),
+    }
+
+
+def _make_alert(minutes_ago: int, severity: str = "high"):
+    ts = _now() - timedelta(minutes=minutes_ago)
+    return {
+        "alert_id": "id",
+        "org_id": 1,
+        "analysis_type": "deforestation",
+        "region_bbox": [-60, -15, -45, 5],
+        "severity": severity,
+        "measured_value": 0.3,
+        "threshold": 0.15,
+        "summary": "test",
+        "triggered_at": ts.isoformat(),
+        "channels": ["log"],
+    }
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(admin.router)
+    return TestClient(app)
+
+
+def test_reports_returns_zeros_for_empty_logs(env):
+    client = _client()
+    resp = client.get("/api/reports?window_hours=24")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run_count"] == 0
+    assert body["error_rate"] == 0.0
+    assert body["mean_confidence"] is None
+    assert body["alert_count"] == 0
+
+
+def test_reports_aggregates_within_window(env):
+    audit, alerts = env
+    _write_audit(audit, [
+        _make_audit_entry(minutes_ago=10, mean_conf=0.8, positive=0.2),
+        _make_audit_entry(minutes_ago=30, mean_conf=0.9, positive=0.4),
+        _make_audit_entry(minutes_ago=60 * 48, mean_conf=0.5, positive=0.1),  # outside
+        _make_audit_entry(minutes_ago=20, mean_conf=0.7, positive=0.3, error=True),
+    ])
+    _write_audit(alerts, [_make_alert(15), _make_alert(60 * 48)])
+
+    client = _client()
+    body = client.get("/api/reports?window_hours=24").json()
+
+    assert body["run_count"] == 3
+    assert pytest.approx(body["error_rate"], rel=1e-3) == 1 / 3
+    assert pytest.approx(body["mean_confidence"], rel=1e-3) == (0.8 + 0.9 + 0.7) / 3
+    assert pytest.approx(body["positive_fraction_mean"], rel=1e-3) == (0.2 + 0.4 + 0.3) / 3
+    assert body["alert_count"] == 1
+
+
+def test_reports_rejects_zero_window(env):
+    client = _client()
+    resp = client.get("/api/reports?window_hours=0")
+    assert resp.status_code == 422
+
+
+def test_anomalies_lists_all_when_unfiltered(env):
+    _, alerts = env
+    _write_audit(alerts, [_make_alert(5, "high"), _make_alert(10, "medium")])
+    body = _client().get("/api/anomalies").json()
+    assert body["count"] == 2
+
+
+def test_anomalies_filters_by_severity(env):
+    _, alerts = env
+    _write_audit(alerts, [_make_alert(5, "high"), _make_alert(10, "medium")])
+    body = _client().get("/api/anomalies?severity=high").json()
+    assert body["count"] == 1
+    assert body["anomalies"][0]["severity"] == "high"
+
+
+def test_anomalies_filters_by_window(env):
+    _, alerts = env
+    _write_audit(alerts, [_make_alert(5, "high"), _make_alert(60 * 48, "high")])
+    body = _client().get("/api/anomalies?window_hours=1").json()
+    assert body["count"] == 1
+
+
+def test_anomalies_rejects_invalid_severity(env):
+    resp = _client().get("/api/anomalies?severity=blah")
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- Adds `src/climatevision/api/admin.py` — a self-contained `APIRouter` (`prefix="/api"`) exposing two read-only operational endpoints:
  - `GET /api/reports?window_hours=N` — data-quality KPIs: run count, error rate, mean confidence, positive-fraction mean, alert count.
  - `GET /api/anomalies?severity=&window_hours=N` — list flagged alert records, optionally filtered.
- Both read from the JSONL logs written by the audit logger (#36) and the alert generator (#41). They never expose raw input payloads — only summary fields safe for an operations dashboard.
- One-line wire-up in `api/main.py` via `app.include_router(admin.router)`.

## Why
Sprint deliverable: "Build a `/api/reports` endpoint returning data quality metrics over configurable time windows" + "Add `/api/anomalies` endpoint for querying flagged predictions." Backs the operational dashboard and on-call tooling.

## Test plan
- [x] `pytest tests/test_api_admin.py` — 7/7 pass
  - empty logs return zeros
  - `/api/reports` aggregates run count, error rate, confidence, positive fraction, alert count within window and excludes records outside
  - `/api/reports?window_hours=0` rejected with 422
  - `/api/anomalies` returns all records when unfiltered
  - `/api/anomalies?severity=high` filters correctly
  - `/api/anomalies?window_hours=1` filters by time window
  - invalid severity rejected with 422 via the regex constraint

## Notes for reviewers
- Branched off `develop`. The router is mounted on the existing `app` in `api/main.py`; no other route handlers are touched.
- Default JSONL paths are read from module-level constants and resolved at call time, so monkeypatching from tests works without restarting the app.
- File-backed reads are O(n) over the JSONL files — fine at expected operational volumes; if log size becomes a concern we can switch the data source to the existing `db.py` once the audit and alert tables ship there.