### PR TITLE
feat(models): add biomass and carbon-stock regression module

### DIFF
--- a/src/climatevision/models/__init__.py
+++ b/src/climatevision/models/__init__.py
@@ -4,9 +4,25 @@ Deep learning models for forest segmentation and change detection
 
 from .unet import UNet, AttentionUNet
 from .siamese import SiameseNetwork
+from .regression import (
+    BiomassRegressor,
+    RegressionMetrics,
+    biomass_to_carbon,
+    biomass_to_co2e,
+    estimate_biomass_from_indices,
+    evaluate_regression,
+    serialize_metrics,
+)
 
 __all__ = [
     'UNet',
     'AttentionUNet',
     'SiameseNetwork',
+    'BiomassRegressor',
+    'RegressionMetrics',
+    'biomass_to_carbon',
+    'biomass_to_co2e',
+    'estimate_biomass_from_indices',
+    'evaluate_regression',
+    'serialize_metrics',
 ]

--- a/src/climatevision/models/regression.py
+++ b/src/climatevision/models/regression.py
@@ -1,0 +1,281 @@
+"""
+Biomass and carbon-stock regression models for ClimateVision.
+
+Where the U-Net produces per-pixel deforestation masks, this module
+turns those masks (plus the underlying spectral indices) into a scalar
+estimate of above-ground biomass (Mg/ha) and the carbon equivalent
+(tCO2e). It supports two regressors out of the box:
+
+- ``"random_forest"`` — sklearn RandomForestRegressor (default).
+- ``"xgboost"``       — XGBRegressor when xgboost is installed.
+
+The conversion from biomass to CO2e uses the IPCC default carbon
+fraction of 0.47 and the molecular-weight ratio 44/12. Both constants
+are exposed so users can override them per ecosystem.
+
+Typical usage::
+
+    from climatevision.models.regression import (
+        BiomassRegressor, biomass_to_carbon, biomass_to_co2e,
+    )
+
+    reg = BiomassRegressor(model_type="random_forest").fit(X_train, y_train)
+    biomass = reg.predict(X_test)        # Mg/ha
+    co2e = biomass_to_co2e(biomass)      # tCO2e/ha
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Sequence, Union
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+CARBON_FRACTION = 0.47           # IPCC default for tropical forests
+CO2_TO_C_RATIO = 44.0 / 12.0     # molecular weight ratio
+DEFAULT_FEATURE_NAMES = (
+    "ndvi",
+    "evi",
+    "savi",
+    "ndmi",
+    "nbr",
+    "red",
+    "green",
+    "blue",
+    "nir",
+    "swir1",
+)
+
+
+def biomass_to_carbon(biomass: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+    """Convert above-ground biomass (Mg/ha) to carbon (tC/ha)."""
+    return np.asarray(biomass) * CARBON_FRACTION
+
+
+def biomass_to_co2e(biomass: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+    """Convert above-ground biomass (Mg/ha) to CO2 equivalent (tCO2e/ha)."""
+    return biomass_to_carbon(biomass) * CO2_TO_C_RATIO
+
+
+@dataclass
+class RegressionMetrics:
+    rmse: float
+    mae: float
+    r2: float
+    mape: float
+
+    def to_dict(self) -> dict[str, float]:
+        return {"rmse": self.rmse, "mae": self.mae, "r2": self.r2, "mape": self.mape}
+
+
+def _safe_mape(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    mask = y_true != 0
+    if not mask.any():
+        return float("nan")
+    return float(np.mean(np.abs((y_true[mask] - y_pred[mask]) / y_true[mask])))
+
+
+def evaluate_regression(y_true: np.ndarray, y_pred: np.ndarray) -> RegressionMetrics:
+    """Compute RMSE / MAE / R² / MAPE for a regression run."""
+    y_true = np.asarray(y_true, dtype=np.float64)
+    y_pred = np.asarray(y_pred, dtype=np.float64)
+    if y_true.shape != y_pred.shape:
+        raise ValueError(
+            f"shape mismatch: y_true={y_true.shape} y_pred={y_pred.shape}"
+        )
+    if y_true.size == 0:
+        raise ValueError("cannot evaluate empty arrays")
+
+    err = y_pred - y_true
+    rmse = float(np.sqrt(np.mean(err ** 2)))
+    mae = float(np.mean(np.abs(err)))
+
+    ss_res = float(np.sum(err ** 2))
+    ss_tot = float(np.sum((y_true - y_true.mean()) ** 2))
+    r2 = float("nan") if ss_tot == 0 else 1.0 - ss_res / ss_tot
+
+    return RegressionMetrics(rmse=rmse, mae=mae, r2=r2, mape=_safe_mape(y_true, y_pred))
+
+
+class BiomassRegressor:
+    """
+    Wrapper around sklearn / xgboost regressors with a stable API for
+    ClimateVision pipelines.
+    """
+
+    SUPPORTED_MODELS = ("random_forest", "xgboost")
+
+    def __init__(
+        self,
+        model_type: str = "random_forest",
+        *,
+        feature_names: Optional[Sequence[str]] = None,
+        model_kwargs: Optional[dict[str, Any]] = None,
+        random_state: int = 42,
+    ) -> None:
+        if model_type not in self.SUPPORTED_MODELS:
+            raise ValueError(
+                f"model_type must be one of {self.SUPPORTED_MODELS}, got {model_type!r}"
+            )
+        self.model_type = model_type
+        self.feature_names = tuple(feature_names) if feature_names else DEFAULT_FEATURE_NAMES
+        self.model_kwargs = dict(model_kwargs or {})
+        self.random_state = random_state
+        self._model: Any = None
+        self._fitted = False
+
+    def _build(self) -> Any:
+        if self.model_type == "random_forest":
+            from sklearn.ensemble import RandomForestRegressor
+
+            kwargs = {
+                "n_estimators": 200,
+                "max_depth": None,
+                "min_samples_leaf": 2,
+                "random_state": self.random_state,
+                "n_jobs": -1,
+            }
+            kwargs.update(self.model_kwargs)
+            return RandomForestRegressor(**kwargs)
+
+        try:
+            from xgboost import XGBRegressor
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise RuntimeError(
+                "xgboost is required for model_type='xgboost'. "
+                "Install with `pip install xgboost`."
+            ) from exc
+
+        kwargs = {
+            "n_estimators": 400,
+            "max_depth": 6,
+            "learning_rate": 0.05,
+            "subsample": 0.9,
+            "objective": "reg:squarederror",
+            "random_state": self.random_state,
+            "n_jobs": -1,
+        }
+        kwargs.update(self.model_kwargs)
+        return XGBRegressor(**kwargs)
+
+    def fit(
+        self,
+        X: np.ndarray,
+        y: np.ndarray,
+        *,
+        sample_weight: Optional[np.ndarray] = None,
+    ) -> "BiomassRegressor":
+        X = np.asarray(X, dtype=np.float64)
+        y = np.asarray(y, dtype=np.float64)
+        if X.ndim != 2:
+            raise ValueError(f"X must be 2-D, got shape {X.shape}")
+        if X.shape[0] != y.shape[0]:
+            raise ValueError(
+                f"row mismatch: X has {X.shape[0]} rows, y has {y.shape[0]}"
+            )
+
+        self._model = self._build()
+        if sample_weight is not None:
+            self._model.fit(X, y, sample_weight=sample_weight)
+        else:
+            self._model.fit(X, y)
+        self._fitted = True
+        logger.info(
+            "Trained %s on %d samples with %d features",
+            self.model_type,
+            X.shape[0],
+            X.shape[1],
+        )
+        return self
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        if not self._fitted:
+            raise RuntimeError("regressor must be fit() before predict()")
+        X = np.asarray(X, dtype=np.float64)
+        return np.asarray(self._model.predict(X), dtype=np.float64)
+
+    def feature_importances(self) -> dict[str, float]:
+        if not self._fitted:
+            raise RuntimeError("regressor must be fit() before feature_importances()")
+        importances = getattr(self._model, "feature_importances_", None)
+        if importances is None:
+            raise AttributeError(
+                f"underlying {self.model_type} has no feature_importances_"
+            )
+        names = self.feature_names
+        if len(names) != len(importances):
+            names = tuple(f"f{i}" for i in range(len(importances)))
+        return {name: float(value) for name, value in zip(names, importances)}
+
+    def evaluate(self, X: np.ndarray, y_true: np.ndarray) -> RegressionMetrics:
+        return evaluate_regression(y_true, self.predict(X))
+
+    def save(self, path: Union[str, Path]) -> Path:
+        if not self._fitted:
+            raise RuntimeError("regressor must be fit() before save()")
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("wb") as fh:
+            pickle.dump(
+                {
+                    "model": self._model,
+                    "model_type": self.model_type,
+                    "feature_names": list(self.feature_names),
+                    "random_state": self.random_state,
+                },
+                fh,
+            )
+        logger.info("Saved %s regressor to %s", self.model_type, path)
+        return path
+
+    @classmethod
+    def load(cls, path: Union[str, Path]) -> "BiomassRegressor":
+        path = Path(path)
+        with path.open("rb") as fh:
+            payload = pickle.load(fh)
+        instance = cls(
+            model_type=payload["model_type"],
+            feature_names=payload["feature_names"],
+            random_state=payload["random_state"],
+        )
+        instance._model = payload["model"]
+        instance._fitted = True
+        return instance
+
+
+def estimate_biomass_from_indices(
+    indices: dict[str, np.ndarray],
+    regressor: BiomassRegressor,
+    feature_order: Optional[Sequence[str]] = None,
+) -> np.ndarray:
+    """
+    Build a feature matrix from a dict of spectral-index arrays and run
+    inference. The dict is expected to map index name -> 1-D array of
+    pixel values (one row per pixel).
+    """
+    feature_order = tuple(feature_order or regressor.feature_names)
+    missing = [k for k in feature_order if k not in indices]
+    if missing:
+        raise KeyError(f"missing spectral indices: {missing}")
+
+    columns = [np.asarray(indices[k]).reshape(-1) for k in feature_order]
+    if len({c.size for c in columns}) != 1:
+        raise ValueError("all input indices must have the same length")
+    X = np.stack(columns, axis=1)
+    return regressor.predict(X)
+
+
+def serialize_metrics(
+    metrics: RegressionMetrics, output_path: Union[str, Path]
+) -> Path:
+    """Persist regression metrics as JSON for the eval / model-card pipeline."""
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(metrics.to_dict(), indent=2))
+    return output_path

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,124 @@
+"""Tests for models.regression.
+
+Imports the module via importlib because ``climatevision.models.__init__``
+pulls in torch-based U-Net code that is heavy and unrelated to the
+regression module under test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "climatevision"
+    / "models"
+    / "regression.py"
+)
+_spec = importlib.util.spec_from_file_location("cv_regression", _PATH)
+reg = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["cv_regression"] = reg
+_spec.loader.exec_module(reg)
+
+
+def _synthetic_dataset(n=400, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.uniform(low=0.0, high=1.0, size=(n, 10))
+    # biomass = 200 * NDVI + 50 * EVI + 20 * NIR + noise
+    y = 200 * X[:, 0] + 50 * X[:, 1] + 20 * X[:, 8] + rng.normal(0, 5, size=n)
+    return X, y
+
+
+def test_biomass_to_carbon_uses_default_fraction():
+    assert reg.biomass_to_carbon(100.0) == pytest.approx(47.0)
+    arr = reg.biomass_to_carbon(np.array([0.0, 100.0, 200.0]))
+    np.testing.assert_allclose(arr, [0.0, 47.0, 94.0])
+
+
+def test_biomass_to_co2e_round_trip():
+    co2e = reg.biomass_to_co2e(100.0)
+    assert co2e == pytest.approx(100.0 * 0.47 * (44.0 / 12.0))
+
+
+def test_evaluate_regression_perfect_fit():
+    y = np.array([1.0, 2.0, 3.0, 4.0])
+    metrics = reg.evaluate_regression(y, y)
+    assert metrics.rmse == 0.0
+    assert metrics.mae == 0.0
+    assert metrics.r2 == pytest.approx(1.0)
+    assert metrics.mape == pytest.approx(0.0)
+
+
+def test_evaluate_regression_shape_mismatch_raises():
+    with pytest.raises(ValueError):
+        reg.evaluate_regression(np.array([1.0, 2.0]), np.array([1.0]))
+
+
+def test_random_forest_fit_predict_evaluate():
+    X, y = _synthetic_dataset(n=300)
+    r = reg.BiomassRegressor(model_type="random_forest", model_kwargs={"n_estimators": 50})
+    r.fit(X, y)
+    metrics = r.evaluate(X, y)
+    assert metrics.rmse < 25.0  # very loose, just sanity
+    assert metrics.r2 > 0.5
+
+    importances = r.feature_importances()
+    assert set(importances) == set(reg.DEFAULT_FEATURE_NAMES)
+    assert pytest.approx(sum(importances.values()), rel=1e-6) == 1.0
+
+
+def test_unsupported_model_type_raises():
+    with pytest.raises(ValueError):
+        reg.BiomassRegressor(model_type="lightgbm")
+
+
+def test_predict_before_fit_raises():
+    r = reg.BiomassRegressor()
+    with pytest.raises(RuntimeError):
+        r.predict(np.zeros((1, 10)))
+
+
+def test_save_and_load_round_trip(tmp_path):
+    X, y = _synthetic_dataset(n=200)
+    r = reg.BiomassRegressor(model_type="random_forest", model_kwargs={"n_estimators": 30})
+    r.fit(X, y)
+
+    out = r.save(tmp_path / "rf.pkl")
+    assert out.exists()
+
+    loaded = reg.BiomassRegressor.load(out)
+    np.testing.assert_allclose(loaded.predict(X), r.predict(X))
+
+
+def test_estimate_biomass_from_indices(tmp_path):
+    X, y = _synthetic_dataset(n=200)
+    r = reg.BiomassRegressor(model_kwargs={"n_estimators": 30}).fit(X, y)
+
+    indices = {name: X[:, i] for i, name in enumerate(reg.DEFAULT_FEATURE_NAMES)}
+    pred = reg.estimate_biomass_from_indices(indices, r)
+    assert pred.shape == (X.shape[0],)
+    np.testing.assert_allclose(pred, r.predict(X))
+
+
+def test_estimate_biomass_missing_index_raises():
+    r = reg.BiomassRegressor(model_kwargs={"n_estimators": 5})
+    r.fit(*_synthetic_dataset(n=80))
+
+    incomplete = {name: np.zeros(10) for name in reg.DEFAULT_FEATURE_NAMES[:-1]}
+    with pytest.raises(KeyError):
+        reg.estimate_biomass_from_indices(incomplete, r)
+
+
+def test_serialize_metrics_writes_json(tmp_path):
+    metrics = reg.RegressionMetrics(rmse=1.0, mae=0.5, r2=0.9, mape=0.05)
+    out = reg.serialize_metrics(metrics, tmp_path / "metrics.json")
+    payload = json.loads(out.read_text())
+    assert payload == {"rmse": 1.0, "mae": 0.5, "r2": 0.9, "mape": 0.05}


### PR DESCRIPTION
## Summary
- Adds `src/climatevision/models/regression.py` — `BiomassRegressor`, a wrapper around sklearn `RandomForestRegressor` and `xgboost.XGBRegressor` with a stable `fit / predict / evaluate / save / load` API.
- Default feature ordering matches the spectral indices produced by the data preprocessor: NDVI, EVI, SAVI, NDMI, NBR, R, G, B, NIR, SWIR1.
- Helpers: `biomass_to_carbon` and `biomass_to_co2e` use IPCC defaults (carbon fraction 0.47, 44/12 ratio for CO2e).
- `evaluate_regression` computes RMSE / MAE / R^2 / MAPE for the eval and model-card pipelines.
- `estimate_biomass_from_indices` accepts a dict of per-pixel index arrays and runs inference in one call.
- Wires symbols into `models/__init__.py`.

## Why
Sprint deliverable: "Build carbon.py — Random Forest & XGBoost regression for biomass prediction" / "Implement metrics for regression evaluation (RMSE, MAE, R-squared)." Backs the carbon analytics module Francis is delivering this sprint.

## Test plan
- [x] `pytest tests/test_regression.py` — 11/11 pass
  - biomass_to_carbon and biomass_to_co2e use the documented constants
  - evaluate_regression returns rmse=mae=0 and r2=1 on a perfect fit
  - shape-mismatch raises ValueError
  - RandomForest fits, predicts, and yields sensible metrics on synthetic data
  - feature_importances() returns one entry per feature name and sums to 1.0
  - unsupported model_type raises ValueError
  - predict() before fit() raises RuntimeError
  - save() / load() round-trip yields identical predictions
  - estimate_biomass_from_indices builds the right feature matrix and matches predict()
  - missing index in the dict raises KeyError
  - serialize_metrics writes a well-formed JSON

## Notes for reviewers
- xgboost is a soft dependency — `import xgboost` is guarded so installs without it still work.
- `models/__init__.py` extends the existing `__all__`; no existing imports are touched.