### PR TITLE
feat(notebooks): add 03_carbon_analysis carbon stock estimation notebook

### DIFF
--- a/notebooks/03_carbon_analysis.ipynb
+++ b/notebooks/03_carbon_analysis.ipynb
@@ -1,0 +1,247 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 03 — Carbon Stock Analysis\n",
+    "\n",
+    "Estimate above-ground biomass (Mg/ha) and carbon stock (tCO2e/ha) from spectral indices using `climatevision.models.regression.BiomassRegressor`.\n",
+    "\n",
+    "**Pipeline**\n",
+    "\n",
+    "1. Load (or simulate) a labelled dataset of spectral indices ↔ biomass.\n",
+    "2. Train a Random Forest regressor and evaluate on a held-out split.\n",
+    "3. Convert biomass predictions to carbon and CO₂e using IPCC defaults.\n",
+    "4. Inspect feature importances to confirm the model is leaning on the indices we expect (NDVI, EVI, NIR).\n",
+    "5. Persist the trained regressor + metrics so the analytics API can serve them."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from climatevision.models.regression import (\n",
+    "    BiomassRegressor,\n",
+    "    biomass_to_carbon,\n",
+    "    biomass_to_co2e,\n",
+    "    evaluate_regression,\n",
+    "    serialize_metrics,\n",
+    ")\n",
+    "\n",
+    "PROJECT_ROOT = Path.cwd().parent if Path.cwd().name == \"notebooks\" else Path.cwd()\n",
+    "OUTPUTS = PROJECT_ROOT / \"outputs\" / \"carbon\"\n",
+    "OUTPUTS.mkdir(parents=True, exist_ok=True)\n",
+    "rng = np.random.default_rng(42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Load training data\n",
+    "\n",
+    "If a real labelled dataset is available at `data/biomass/biomass_samples.parquet`, load it. Otherwise simulate a plausible one so the notebook is runnable in CI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_PATH = PROJECT_ROOT / \"data\" / \"biomass\" / \"biomass_samples.parquet\"\n",
+    "FEATURE_COLS = [\"ndvi\", \"evi\", \"savi\", \"ndmi\", \"nbr\", \"red\", \"green\", \"blue\", \"nir\", \"swir1\"]\n",
+    "\n",
+    "if DATA_PATH.exists():\n",
+    "    df = pd.read_parquet(DATA_PATH)\n",
+    "    print(f\"Loaded {len(df):,} real samples from {DATA_PATH}\")\n",
+    "else:\n",
+    "    n = 5_000\n",
+    "    X = rng.uniform(0, 1, size=(n, len(FEATURE_COLS)))\n",
+    "    biomass = (\n",
+    "        220 * X[:, 0]   # NDVI\n",
+    "        + 80 * X[:, 1]  # EVI\n",
+    "        + 30 * X[:, 8]  # NIR\n",
+    "        - 20 * X[:, 5]  # Red\n",
+    "        + rng.normal(0, 8, size=n)\n",
+    "    )\n",
+    "    df = pd.DataFrame(X, columns=FEATURE_COLS)\n",
+    "    df[\"biomass_mg_ha\"] = np.clip(biomass, 0, None)\n",
+    "    print(f\"No real dataset found, simulated {n:,} samples\")\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Train / test split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "split_idx = int(0.8 * len(df))\n",
+    "perm = rng.permutation(len(df))\n",
+    "train_idx, test_idx = perm[:split_idx], perm[split_idx:]\n",
+    "\n",
+    "X_train = df.loc[train_idx, FEATURE_COLS].to_numpy()\n",
+    "y_train = df.loc[train_idx, \"biomass_mg_ha\"].to_numpy()\n",
+    "X_test = df.loc[test_idx, FEATURE_COLS].to_numpy()\n",
+    "y_test = df.loc[test_idx, \"biomass_mg_ha\"].to_numpy()\n",
+    "\n",
+    "print(f\"train={X_train.shape[0]:,}  test={X_test.shape[0]:,}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Train a Random Forest regressor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "regressor = BiomassRegressor(\n",
+    "    model_type=\"random_forest\",\n",
+    "    feature_names=FEATURE_COLS,\n",
+    "    model_kwargs={\"n_estimators\": 300, \"min_samples_leaf\": 2},\n",
+    ")\n",
+    "regressor.fit(X_train, y_train)\n",
+    "\n",
+    "metrics = regressor.evaluate(X_test, y_test)\n",
+    "print(f\"RMSE = {metrics.rmse:.2f} Mg/ha\")\n",
+    "print(f\"MAE  = {metrics.mae:.2f} Mg/ha\")\n",
+    "print(f\"R^2  = {metrics.r2:.3f}\")\n",
+    "print(f\"MAPE = {metrics.mape:.2%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Convert to carbon and CO₂e"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predicted_biomass = regressor.predict(X_test)\n",
+    "predicted_carbon = biomass_to_carbon(predicted_biomass)\n",
+    "predicted_co2e = biomass_to_co2e(predicted_biomass)\n",
+    "\n",
+    "summary = pd.DataFrame({\n",
+    "    \"biomass_mg_ha\": predicted_biomass,\n",
+    "    \"carbon_t_ha\": predicted_carbon,\n",
+    "    \"co2e_t_ha\": predicted_co2e,\n",
+    "})\n",
+    "summary.describe().round(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Feature importances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "importances = regressor.feature_importances()\n",
+    "imp_df = pd.Series(importances).sort_values(ascending=False)\n",
+    "imp_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib\n",
+    "matplotlib.use(\"Agg\")\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "imp_df.plot.bar(ax=ax)\n",
+    "ax.set_title(\"Feature importances — biomass regressor\")\n",
+    "ax.set_ylabel(\"Importance\")\n",
+    "plt.tight_layout()\n",
+    "fig.savefig(OUTPUTS / \"feature_importances.png\", dpi=150)\n",
+    "plt.close(fig)\n",
+    "print(f\"Wrote {OUTPUTS / 'feature_importances.png'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Persist artifacts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_path = regressor.save(PROJECT_ROOT / \"models_pretrained\" / \"biomass_rf.pkl\")\n",
+    "metrics_path = serialize_metrics(metrics, OUTPUTS / \"metrics.json\")\n",
+    "print(f\"Model:   {model_path}\")\n",
+    "print(f\"Metrics: {metrics_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- See `04_model_validation.ipynb` for a held-out validation sweep across the Amazon, Congo, and Southeast Asia regions.\n",
+    "- See `05_impact_reporting.ipynb` for how to plug these carbon estimates into a stakeholder report."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Adds `notebooks/03_carbon_analysis.ipynb` — end-to-end walk-through of training a `BiomassRegressor`, evaluating it, converting biomass to carbon and CO2e, plotting feature importances, and persisting the model + metrics.
- Loads `data/biomass/biomass_samples.parquet` if present; otherwise simulates a 5,000-sample synthetic dataset so the notebook is runnable in CI.
- Persists the trained model to `models_pretrained/biomass_rf.pkl` and the metrics to `outputs/carbon/metrics.json` for the analytics API and model-card pipeline.

## Why
Sprint deliverable: "Create 03_carbon_analysis.ipynb — Carbon estimation analysis."

## Test plan
- [x] `python -c 'import json; json.load(open("notebooks/03_carbon_analysis.ipynb"))'` — valid notebook JSON.
- Notebook runs top-to-bottom on synthetic data without errors when executed via `papermill notebooks/03_carbon_analysis.ipynb /tmp/out.ipynb`.

## Notes for reviewers
- Depends on `BiomassRegressor` introduced in #46; merge that first.
- `OUTPUTS` resolves correctly whether the notebook is run from the repo root or from `notebooks/`.