### PR TITLE
docs: remove references to nonexistent requirements-dev.txt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,6 @@ Ready for something meatier? These issues close critical gaps in our production 
    source venv/bin/activate
    pip install -r requirements.txt
    pip install -e .
-   pip install -r requirements-dev.txt
    ```
 
 4. **Make your changes**

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -18,7 +18,6 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 # Install dependencies
 pip install --upgrade pip
 pip install -r requirements.txt
-pip install -r requirements-dev.txt
 
 # Install in editable mode
 pip install -e .

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -280,8 +280,8 @@ Post-processing (inference/)
 
 1. **Set up development environment**
    ```bash
+   pip install -r requirements.txt
    pip install -e .
-   pip install -r requirements-dev.txt
    ```
 
 2. **Run existing code**


### PR DESCRIPTION
## Summary

`GETTING_STARTED.md`, `CONTRIBUTING.md`, and `PROJECT_STRUCTURE.md` instruct contributors to run `pip install -r requirements-dev.txt`, but that file does not exist in the repo, so setup fails at that step. All development tools (pytest, pytest-cov, black, flake8) are already provided by `requirements.txt`, so the extra install step is removed. `PROJECT_STRUCTURE.md`'s dev-setup snippet now installs `requirements.txt` before the editable install so the documented flow works end to end.

## Related Issue

N/A — documentation fix found during setup.

## Type of Change

- [x] Documentation update

## Key Changes

- Remove `pip install -r requirements-dev.txt` from `GETTING_STARTED.md`
- Remove the same broken step from `CONTRIBUTING.md`
- Fix the dev-setup snippet in `PROJECT_STRUCTURE.md` to install `requirements.txt` before the editable install

## Testing

- [x] Followed the documented setup flow end to end with the corrected instructions

## Checklist

- [x] Self-review completed
- [x] Documentation updated where needed
