### PR TITLE
ci: pin GitHub Actions to commit SHAs (2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,10 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  # v5
         with:
           context: .
           push: false


### PR DESCRIPTION
## Why

Mutable Action tags (`@v4`, `@main`) can be retagged, which is a supply-chain risk.
This PR pins third-party Actions to full commit SHAs while keeping the tag in a comment.
Official `actions/*` tags are left unchanged (common maintainer preference).

## Pins

- `docker/setup-buildx-action@v3 -> 8d2750c68a42`
- `docker/build-push-action@v5 -> ca052bb54ab0`

Reference: GitHub docs on using third-party actions securely.
